### PR TITLE
Added printScaling attribute to document

### DIFF
--- a/src/z3c/rml/document.py
+++ b/src/z3c/rml/document.py
@@ -442,6 +442,13 @@ class IDocInit(interfaces.IRMLDirectiveSignature):
         description=u'A flag when set shows crop marks on the page.',
         required=False)
 
+    printScaling = attr.Choice(
+        title=u'Print Scaling',
+        description=(u'The print scaling mode in which the document is opened '
+        u'in the viewer.'),
+        choices=('None', 'AppDefault'),
+        required=False)
+
 
 class DocInit(directive.RMLDirective):
     signature = IDocInit
@@ -463,6 +470,7 @@ class DocInit(directive.RMLDirective):
         self.parent.cropMarks = kwargs.get('useCropMarks', False)
         self.parent.pageMode = kwargs.get('pageMode')
         self.parent.pageLayout = kwargs.get('pageLayout')
+        self.parent.printScaling = kwargs.get('printScaling')
         super(DocInit, self).process()
 
 
@@ -527,6 +535,7 @@ class Document(directive.RMLDirective):
         self.pageLayout = None
         self.pageMode = None
         self.logger = None
+        self.printScaling = None
 
     def _indexAdd(self, canvas, name, label):
         self.indexes[name](canvas, name, label)
@@ -542,6 +551,10 @@ class Document(directive.RMLDirective):
             canvas._doc._catalog.setPageLayout(self.pageLayout)
         if self.pageMode:
             canvas._doc._catalog.setPageMode(self.pageMode)
+        if self.printScaling:
+            canvas.setViewerPreference(
+                'PrintScaling', self.printScaling
+            )
 
     def process(self, outputFile=None):
         """Process document"""

--- a/src/z3c/rml/rml.dtd
+++ b/src/z3c/rml/rml.dtd
@@ -9,6 +9,7 @@
 <!ATTLIST docinit pageMode (usenone|fullscreen|usethumbs|useoutlines) #IMPLIED>
 <!ATTLIST docinit pageLayout (twocolumnright|onecolumn|twocolumnleft|singlepage) #IMPLIED>
 <!ATTLIST docinit useCropMarks CDATA #IMPLIED>
+<!ATTLIST docinit printScaling (none|appdefault) #IMPLIED>
 
 <!ELEMENT color>
 <!ATTLIST color id CDATA #REQUIRED>

--- a/src/z3c/rml/tests/expected/printScaling.pdf
+++ b/src/z3c/rml/tests/expected/printScaling.pdf
@@ -1,0 +1,102 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+% 'BasicFonts': class PDFDictionary 
+1 0 obj
+% The standard fonts dictionary
+<< /F1 2 0 R >>
+endobj
+% 'F1': class PDFType1Font 
+2 0 obj
+% Font Helvetica
+<< /BaseFont /Helvetica
+ /Encoding /WinAnsiEncoding
+ /Name /F1
+ /Subtype /Type1
+ /Type /Font >>
+endobj
+% 'Page1': class PDFPage 
+3 0 obj
+% Page dictionary
+<< /Contents 7 0 R
+ /MediaBox [ 0
+ 0
+ 595.2756
+ 841.8898 ]
+ /Parent 6 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ] >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'R4': class PDFCatalog 
+4 0 obj
+% Document Root
+<< /Outlines 8 0 R
+ /PageMode /UseNone
+ /Pages 6 0 R
+ /Type /Catalog
+ /ViewerPreferences 9 0 R >>
+endobj
+% 'R5': class PDFInfo 
+5 0 obj
+<< /Author (\(anonymous\))
+ /CreationDate (D:20130305110745+00'00')
+ /Creator (\(unspecified\))
+ /Keywords ()
+ /Producer (ReportLab PDF Library - www.reportlab.com)
+ /Subject (\(unspecified\))
+ /Title (\(anonymous\)) >>
+endobj
+% 'R6': class PDFPages 
+6 0 obj
+% page tree
+<< /Count 1
+ /Kids [ 3 0 R ]
+ /Type /Pages >>
+endobj
+% 'R7': class PDFStream 
+7 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 194 >>
+stream
+GappW5mkI_&4Q>Egu0p:7Es>jR'!#32o8fB2Q_rq<nh5[V`.)-q$[\EH$k4$6YY-nfJ1q^!p/>U<+H1-LcnE$OFhptO_6!)8u(,(9NTt(IO7<+@(]#B2=rgtQiC5hZK<7lJibp-%X%9cD8t'7TsqOm/fl@:SqH8^\Q=FT'=MULkiX8e$=9PqV\D\l#"6E_ao~>endstream
+endobj
+% 'R8': class PDFOutlines 
+8 0 obj
+<< /Count 0
+ /Type /Outlines >>
+endobj
+% 'R9': class ViewerPreferencesPDFDictionary 
+9 0 obj
+<< /PrintScaling /None >>
+endobj
+xref
+0 10
+0000000000 65535 f
+0000000113 00000 n
+0000000209 00000 n
+0000000372 00000 n
+0000000649 00000 n
+0000000810 00000 n
+0000001079 00000 n
+0000001184 00000 n
+0000001520 00000 n
+0000001618 00000 n
+trailer
+<< /ID 
+ % ReportLab generated PDF document -- digest (http://www.reportlab.com) 
+ [(\353.c\257\357w]\205\004\372Cs\023\032\030\320) (\353.c\257\357w]\205\004\372Cs\023\032\030\320)] 
+
+ /Info 5 0 R
+ /Root 4 0 R
+ /Size 10 >>
+startxref
+1662
+%%EOF

--- a/src/z3c/rml/tests/input/printScaling.rml
+++ b/src/z3c/rml/tests/input/printScaling.rml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="iso-8859-1" standalone="no" ?>
+<!DOCTYPE document SYSTEM "../rml.dtd">
+<document filename="printScaling.pdf">
+
+<docinit printScaling="None">
+</docinit>
+
+<template pagesize="210mm,297mm" showBoundary="0">
+
+    <pageTemplate id="main">
+        <frame id="main" x1="15mm" y1="180mm" width="200mm" height="50mm" />
+    </pageTemplate>
+</template>
+
+<story>
+    <para>This document should print at actual size by default</para>
+</story>
+
+</document>

--- a/src/z3c/rml/tests/test_rml.py
+++ b/src/z3c/rml/tests/test_rml.py
@@ -106,6 +106,26 @@ class ComparePDFTestCase(unittest.TestCase):
             n += 1
 
 
+class CompareFileTestCase(unittest.TestCase):
+
+    def __init__(self, testPath, contains):
+        self._testPath = testPath
+        self._contains = contains
+        unittest.TestCase.__init__(self)
+
+    def runTest(self):
+        f = open(self._testPath, 'rb')
+        try:
+            contents = f.read()
+
+            if self._contains not in contents:
+                self.fail(
+                    'PDF file does not contain: %s' % self._contains
+                )
+        finally:
+            f.close()
+
+
 def test_suite():
    suite = unittest.TestSuite()
    inputDir = os.path.join(os.path.dirname(z3c.rml.tests.__file__), 'input')
@@ -123,11 +143,15 @@ def test_suite():
        TestCase = type(filename[:-4], (RMLRenderingTestCase,), {})
        case = TestCase(inPath, outPath)
        suite.addTest(case)
-
        # ** Test PDF rendering correctness **
        TestCase = type('compare-'+filename[:-4], (ComparePDFTestCase,), {})
        case = TestCase(expectPath, outPath)
        suite.addTest(case)
+
+       if filename == 'printScaling.rml':
+            TestCase = type('compare-file-'+filename[:-4], (CompareFileTestCase,), {})
+            case = TestCase(outPath, '<< /PrintScaling /None >>')
+            suite.addTest(case)
 
    return suite
 


### PR DESCRIPTION
The ReportLab canvas has the method `setViewerPreferences` that lets you set some default preferences for viewers that open your PDF. The possible values are shown in `reportlab.pdfbase.pdfdoc.ViewerPreferencesPDFDictionary`:

```
HideToolbar=checkPDFBoolean,
HideMenubar=checkPDFBoolean,
HideWindowUI=checkPDFBoolean,
FitWindow=checkPDFBoolean,
CenterWindow=checkPDFBoolean,
DisplayDocTitle=checkPDFBoolean,    #contributed by mark Erbaugh
NonFullScreenPageMode=checkPDFNames(*'UseNone UseOutlines UseThumbs UseOC'.split()),
Direction=checkPDFNames(*'L2R R2L'.split()),
ViewArea=checkPDFNames(*'MediaBox CropBox BleedBox TrimBox ArtBox'.split()),
ViewClip=checkPDFNames(*'MediaBox CropBox BleedBox TrimBox ArtBox'.split()),
PrintArea=checkPDFNames(*'MediaBox CropBox BleedBox TrimBox ArtBox'.split()),
PrintClip=checkPDFNames(*'MediaBox CropBox BleedBox TrimBox ArtBox'.split()),
PrintScaling=checkPDFNames(*'None AppDefault'.split()),
```

The most useful of these is `PrintScaling` which allows you to set the default print size to the actual document size which is good if you're printing anything that requires precision.

I needed this option so I quickly added it to the `document` element but it might be worth implementing them all somehow. None of them are available in RML2PDF.

Something similar that might be useful would be the ability to set `OpenAction` (still misspelt `OptionActions` in ReportLab 2.6) which allows you to set some javascript that is run when the PDF is opened. This is usually used to open the print dialog automatically.
