### PR TITLE
Some performance tweaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.pdf -crlf diff=astextplain
+*.PDF -crlf diff=astextplain

--- a/src/z3c/rml/__init__.py
+++ b/src/z3c/rml/__init__.py
@@ -1,4 +1,7 @@
-
 # Hook up our custom paragraph parser.
 import z3c.rml.paraparser
 import z3c.rml.rlfix
+
+
+from reportlab.lib.styles import getSampleStyleSheet
+SampleStyleSheet = getSampleStyleSheet()

--- a/src/z3c/rml/directive.py
+++ b/src/z3c/rml/directive.py
@@ -19,6 +19,7 @@ import zope.schema
 
 from lxml import etree
 from z3c.rml import interfaces
+from z3c.rml.attr import getManager
 
 logging.raiseExceptions = False
 logger = logging.getLogger("z3c.rml")
@@ -48,8 +49,18 @@ class RMLDirective(object):
     def getAttributeValues(self, ignore=None, select=None, attrMapping=None,
                            includeMissing=False, valuesOnly=False):
         """See interfaces.IRMLDirective"""
+        manager = getManager(self)
+        cache = '%s.%s' % (self.signature.__module__, self.signature.__name__)
+        if cache in manager.attributesCache:
+            fields = manager.attributesCache[cache]
+        else:
+            fields = []
+            for name, attr in zope.schema.getFieldsInOrder(self.signature):
+                fields.append((name, attr))
+            manager.attributesCache[cache] = fields
+
         items = []
-        for name, attr in zope.schema.getFieldsInOrder(self.signature):
+        for name, attr in fields:
             # Only add the attribute to the list, if it is supposed there
             if ((ignore is None or name not in ignore) and
                 (select is None or name in select)):

--- a/src/z3c/rml/document.py
+++ b/src/z3c/rml/document.py
@@ -579,6 +579,7 @@ class IDocument(interfaces.IRMLDirectiveSignature):
     debug = attr.Boolean(
         title=u'Debug',
         description=u'A flag to activate the debug output.',
+        default=False,
         required=False)
 
     compression = attr.BooleanWithDefault(
@@ -622,6 +623,7 @@ class Document(directive.RMLDirective):
         self.pageMode = None
         self.logger = None
         self.svgs = {}
+        self.attributesCache = {}
         for name in DocInit.viewerOptions:
             setattr(self, name, None)
 
@@ -648,6 +650,10 @@ class Document(directive.RMLDirective):
         # Reset all reportlab global variables. This is very important for
         # ReportLab not to fail.
         reportlab.rl_config._reset()
+
+        debug = self.getAttributeValues(select=('debug',), valuesOnly=True)[0]
+        if not debug:
+            reportlab.rl_config.shapeChecking = 0
 
         # Add our colors mapping to the default ones.
         colors.toColor.setExtraColorsNameSpace(self.colors)
@@ -694,6 +700,7 @@ class Document(directive.RMLDirective):
 
         # Cleanup.
         colors.toColor.setExtraColorsNameSpace({})
+        reportlab.rl_config.shapeChecking = 1
 
     def get_name(self, name, default=None):
         if default is None:

--- a/src/z3c/rml/flowable.py
+++ b/src/z3c/rml/flowable.py
@@ -25,7 +25,7 @@ import zope.schema
 from reportlab.lib import styles, pygments2xpre
 from xml.sax.saxutils import unescape
 from z3c.rml import attr, directive, interfaces, occurence
-from z3c.rml import form, platypus, special, stylesheet
+from z3c.rml import form, platypus, special, SampleStyleSheet, stylesheet
 
 try:
     import reportlab.graphics.barcode
@@ -188,7 +188,7 @@ class IPreformatted(IMinimalParagraphBase):
         description=(u'The paragraph style that is applied to the paragraph. '
                      u'See the ``paraStyle`` tag for creating a paragraph '
                      u'style.'),
-        default=reportlab.lib.styles.getSampleStyleSheet()['Code'],
+        default=SampleStyleSheet['Code'],
         required=False)
 
     text = attr.RawXMLContent(
@@ -218,7 +218,7 @@ class IXPreformatted(IParagraphBase):
         description=(u'The paragraph style that is applied to the paragraph. '
                      u'See the ``paraStyle`` tag for creating a paragraph '
                      u'style.'),
-        default=reportlab.lib.styles.getSampleStyleSheet()['Normal'],
+        default=SampleStyleSheet['Normal'],
         required=False)
 
     text = attr.RawXMLContent(
@@ -277,7 +277,11 @@ class Paragraph(Flowable):
     styleAttributes = zope.schema.getFieldNames(stylesheet.IBaseParagraphStyle)
 
     def processStyle(self, style):
-        attrs = self.getAttributeValues(select=self.styleAttributes)
+        attrs = []
+        for attr in self.styleAttributes:
+            if self.element.get(attr) is not None:
+                attrs.append(attr)
+        attrs = self.getAttributeValues(select=attrs)
         if attrs:
             style = copy.deepcopy(style)
             for name, value in attrs:

--- a/src/z3c/rml/rlfix.py
+++ b/src/z3c/rml/rlfix.py
@@ -27,7 +27,11 @@ def resetPdfForm():
     pdfform.ZADB = PDFPattern(pdfform.ZaDbPattern)
 
 def resetFonts():
-    for f in testshapes._setup():
+    # testshapes._setup registers the Vera fonts every time which is a little
+    # slow on all platforms. On Windows it lists the entire system font
+    # directory and registers them all which is very slow.
+    for f in ('Times-Roman','Courier','Helvetica','Vera', 'VeraBd', 'VeraIt',
+              'VeraBI'):
         if f not in testshapes._FONTS:
             testshapes._FONTS.append(f)
 

--- a/src/z3c/rml/stylesheet.py
+++ b/src/z3c/rml/stylesheet.py
@@ -17,7 +17,8 @@ import copy
 import reportlab.lib.styles
 import reportlab.lib.enums
 import reportlab.platypus
-from z3c.rml import attr, directive, interfaces, occurence, special
+from z3c.rml import attr, directive, interfaces, occurence, SampleStyleSheet, \
+    special
 
 
 class IInitialize(interfaces.IRMLDirectiveSignature):
@@ -202,7 +203,7 @@ class ParagraphStyle(directive.RMLDirective):
     def process(self):
         kwargs = dict(self.getAttributeValues())
         parent = kwargs.pop(
-            'parent', reportlab.lib.styles.getSampleStyleSheet()['Normal'])
+            'parent', SampleStyleSheet['Normal'])
         name = kwargs.pop('name')
         style = copy.deepcopy(parent)
         style.name = name[6:] if name.startswith('style.') else name

--- a/src/z3c/rml/tests/expected/rml-examples-029-keepinframe.pdf
+++ b/src/z3c/rml/tests/expected/rml-examples-029-keepinframe.pdf
@@ -1,0 +1,211 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+% 'BasicFonts': class PDFDictionary 
+1 0 obj
+% The standard fonts dictionary
+<< /F1 2 0 R
+ /F2 3 0 R
+ /F3 4 0 R >>
+endobj
+% 'F1': class PDFType1Font 
+2 0 obj
+% Font Helvetica
+<< /BaseFont /Helvetica
+ /Encoding /WinAnsiEncoding
+ /Name /F1
+ /Subtype /Type1
+ /Type /Font >>
+endobj
+% 'F2': class PDFType1Font 
+3 0 obj
+% Font Helvetica-BoldOblique
+<< /BaseFont /Helvetica-BoldOblique
+ /Encoding /WinAnsiEncoding
+ /Name /F2
+ /Subtype /Type1
+ /Type /Font >>
+endobj
+% 'F3': class PDFType1Font 
+4 0 obj
+% Font Times-Bold
+<< /BaseFont /Times-Bold
+ /Encoding /WinAnsiEncoding
+ /Name /F3
+ /Subtype /Type1
+ /Type /Font >>
+endobj
+% 'Page1': class PDFPage 
+5 0 obj
+% Page dictionary
+<< /Contents 12 0 R
+ /MediaBox [ 0
+ 0
+ 595
+ 842 ]
+ /Parent 11 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ] >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'Page2': class PDFPage 
+6 0 obj
+% Page dictionary
+<< /Contents 13 0 R
+ /MediaBox [ 0
+ 0
+ 595
+ 842 ]
+ /Parent 11 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ] >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'Page3': class PDFPage 
+7 0 obj
+% Page dictionary
+<< /Contents 14 0 R
+ /MediaBox [ 0
+ 0
+ 595
+ 842 ]
+ /Parent 11 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ] >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'Page4': class PDFPage 
+8 0 obj
+% Page dictionary
+<< /Contents 15 0 R
+ /MediaBox [ 0
+ 0
+ 595
+ 842 ]
+ /Parent 11 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ] >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'R9': class PDFCatalog 
+9 0 obj
+% Document Root
+<< /Outlines 16 0 R
+ /PageMode /UseNone
+ /Pages 11 0 R
+ /Type /Catalog >>
+endobj
+% 'R10': class PDFInfo 
+10 0 obj
+<< /Author (\(anonymous\))
+ /CreationDate (D:20130304202929+00'00')
+ /Creator (\(unspecified\))
+ /Keywords ()
+ /Producer (ReportLab PDF Library - www.reportlab.com)
+ /Subject (\(unspecified\))
+ /Title (\(anonymous\)) >>
+endobj
+% 'R11': class PDFPages 
+11 0 obj
+% page tree
+<< /Count 4
+ /Kids [ 5 0 R
+ 6 0 R
+ 7 0 R
+ 8 0 R ]
+ /Type /Pages >>
+endobj
+% 'R12': class PDFStream 
+12 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 3047 >>
+stream
+Gb!#^gQL=$&Uekgs.QLaOE#$:'ec;[7m$7:SFUQ@f2IqN^H`JY_59aA,],&=T@4oOJeCLmZsHg]'no-;T[B+Ti&ER6Do_bp*Je#ddSCA`3A*I4amj"-4hd[MO3aGHIf@QM\`AE+juTj,1kl%/f&M#C/.;UfkAtr3d,".T^N4o'`reKI]V,"q.O;^/*r[p==7f),ltu<d`Bh52a,flf2l#lOkKacEc=^Ps3'R/pC?@,2:qiH`)u??V]f1aZi;s+Q=o7j%1Mu7""742:43^g^0KabD2dbiUB+p@4)#[5@hJ'GOn+H*7BcqoT7hPu^'B6Xi]D1c@ji,lp!,biWDWg-jWg+\#.]9I"NbL*>iesUn-'6(1PGCn9K$l4Wb)94@mn)RLZ8bR%GU<U(R(H?e4r](JE^#ua0BWJFCDbr?HkiXsj_6LNRSpL/>""(olG!t1@[6:PPntpE=FQAe]t:0DgM&q816te2dKC,BUln'BRkg-GMUJ;^hhk;3\J.K3)tVp'A?69n%5^ZO_rjp3H&tUKB,o0"M^7"d?*]bf;N.KXe=qK]Y6l*Z1OYH.<.YF>ngMa.Ct[#E^i7A(q2Ot*@@bCo1.+gCh-X(HX+JmUi#\ADe-9l:8,!3dUQS[]'Ps*HXg/3rm,1#3!G*HMA=`mflp;NC/Z`I_kCkN52@!%=08u40"$DHO<f"/@<H4h::(O]H9#JAi[G0/c4#u'?nD@t,5.p[[!etEdISngdI&GP2S7-;.LDuPN+d0/_c/h**;r(,H8RAV=WsuC"QKqcohgCXS@b-d]-5%N52$o:pI)(L@PC,8;67!S=ab25O_k^kLBd\]fP="<fiFo4A1<+;Hc?(]s757&9O*nG_P'2sTQ>0eXBZ#jt(iR;A'FX]5fL[Q6f`]=NY5hNC`4@uk"J1-Z*cmTJ@>6r:8Ke?O=`"qq?sa\bQAo;>Z3\17&%pa;]BU1E@qVo6Ut)Fco0OLCk$$iu;AiuIr"d7_c>-EMh+"jNV@Xh*qMunc&4EUrfGq0/9WA3!`@Iu,-\inA%$<'#aIUCm2?[JSi;=L=@ok3s!g9*'cdb(BD"UbGn.fsd6BgFLVJO-_?>DIB=;3*S!q,-Ya@D6Z:*r*CRu9Z],50O?U%&quX=%#9b2BggfdcX-TusSF="^eCW=8I_G1sg(H(MX\X:2g%QCn-4_I-AogA)#j(UGLP8-FPo2t1J*Ej5n=bj-/QSb:=p_-,:taEL[^hMPG&P(Vk%B9H[/CNQD.-0NHCH3<`T9'<dE@p/^mNSD\(X19`&NQWt*,jQUN^f]6(+&G7P3@i:>RSQkjl%n.XIq^?En`79%?uaMt]LPO5?GX%RjJ1/K3M(dN!P'^"cWcT?#PC"he-+IO`\KLS8:jJ(Q3l)'Q,kC^RQ2$l(X#iD#`'J<j41`=pe)h_U(K\8fk;CFPZl^B1r<=63ic<AW%X]p8);5mgSG,qa9a>U0k^5=PP6Su,R^1BWg;C7ECjA^Jg36]NFKg,S2qm0YbOcDD##M>l9)(:E7@H67lcg;[\-*B>&@t..U=FK9):#hKr+CK"P4Ob*F!nS0()p\ecUcO829o^0-mspG/PDfNQUcp;h`,CS131lidX.`lLXKE"P7T/oTa\.fE$jg\t`YnP&;=Mjs*"J/ZfV6BLdGs`4&5VHc30Ygs?tuLN[3:O"BW0&;YK4&']nD=sNslNWbY+IV;56Hc36\C`>@B%;Z^1(9e7pmQYgh-l?+[agW)VmH$DSelLqhDs+Q:,BBd&@[bPQ6M'0!Ba0Lk$JE3Kc2)KC/Y%O<@,^`3c'mcXQ"drVe'hNSo:GM9d`SKCG1D/`IV`:C%/R.M-?o15l0.M8ms8VBK,oB8_sZmU#p$_0Vk&&(<=@^9ZW!c'[p#tdSt-(3p!+RCe$IL6m+(@57rL%hY4q52f:uQJHI8eBKH@gp?h`hBX[ab>2n.!kd\G8VDr/$83Ub@0;K(EjBWbjBo]FZsjL0Z@]fBBeakQWX]fCN(St,e>?mmo!MK?j`L&BfuUQ*JBXg/kCfYEfc<#$mo)s'k&qZ/=>-N"9Z]^OWpCuK[!@,dNKeu:ZJ/U)e@Z6Ke0)6&Y[gqG.qJ8pojKi)F:FtN$j81_c5i5\u7I&AM,%@pEJdSCMPapcl#\l[:No,E$!mpM4@CHhKP7-=VolXL/Y]-b7/Zr2HGS'``ILlXf#fg$Et&8P3^)nDAq!$#>Ik>"\'k@)'551[-dR"t@jqK.<ZZ7q>,Q9uNe_ElG7,L`q0<>&$OZb$siBD8iuZb%5?QhRn+$Q/Gj'/8:+gg=BI_1(C-e1^PMQ.1<.mBQroa9W3f0;Z(cANeY+N3nNOF^Xt,Uq;1:<NC$`XF`T;f:_95U8W`Zc%1f68=<6+Ngiu:^a\3Ukq4RZW^99=GE#lVZPD-T84115:Zkd:X"0isSP4hd$sQOCP;,/k(E=5Ed`,66r8=4C.9oZ!a6rDN=OfN9\3\B>WmAqsE/A;#\*.7#:,m<c@!*-jEc"j2$E=a*Sam2#q88,q(H]@g=kKG$EoF0KrdP[,QXS40*cTj%ag8'--Pk<Z)UJ8tDb_o0YgG4kB3fZ=b?O+#mmMKs<U7'14H#fJYO#)qi)rG96I,@+UZ^pSO<;EE\o6hNj]Ci]O%.Yuq%]IjW^bB8IeBU<^QTI;mnBnT/%XhJLO"la$G:Z?>W/4F`V_La3F6Z'epD2<h"sG%@]Y3(h0)r!DhV2@7dFWEoQ6ri?q%\h?=A_5$U^^5B%Y,C'o#8g0LNFk#b0pFQm(;2#^^k,X3mER#jGA:pq?P%+3FS1?T_\.ITDeW@XrP>o6X*?lt:ch,NGPU9^ejjVkFgt`qh-7%\XkKalLG_p>tuITZqFI8[tiV+/k0`BkB/(/A&r<ISbeMIX."i;iA/e73Z/A7KsHNXUm=X/'X^5')eL3YOcF@n%JRlU:4Fr:"`RRh;@#&@\:hP#[+('3aq8P+E?r_4LM:tC#8,lbjm.><^EE1r@7J3LZ&q`"V_*_^AhOso(CBoYdI*ubf/^S?'Y2:CI=3eKi=jX<!;Q%[kH>RYg%m2o+h1skKj,4Wl54L~>endstream
+endobj
+% 'R13': class PDFStream 
+13 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 1190 >>
+stream
+Gb"/$9lJcU&A9%PIi+st3H,gaa>.o%V.]uGE8.0#OGbbZE_(&Qgnf4]MO@i/fqh)/:"oA=TI=4#Q=0-"p:WD'AeKpq-OHDV$h2U\?>gHI;V9Q^/>FM-n)2Iao&AX!,+PKkjSg])U=Jdm&!B;O,YOmp?U5aRY\dh=a00^OgRgF/-0sK;0-%g/nXgo_F:Fju\mNt,?qXS*r<V/E+lU&V$O+"ZPcn-0&sh33b&1]aIN(YC0>S44pCUPS'<Uk;2M[ko0]jU_.5]<@&BelW5TBi!F2fDYAa\NlhIK-fW@,=)lM!H0>3aH'it:e?Kg%VG!CFU?RDie6(LHS0#1h%_?noV#Mm\@.Kgo2!SZqTd8-oIeE)5u.B8*2W7*qWITPM=LP',Ief74X4<fR+p%ZoSMKsT1Ui4cd*7nK"dTauCo:hF_4@?08XYX_HI=$sMcK;Be;^(;Ds<D>-J'.$3'PD$R6$*a$f/4h=^d#*qqXKs^ol:\.SW)>-9O01u"6Kia(5XeSX9FBQmY)&d,?5REK3IZtu$A5A6nbp8T..-/D[3UBb.[HAT.%^\nh$V+S&D0m)F':4OPe-6-4b=^.6H]YOBen*89f'QSQ!'$5Vbj4g(m\fZ4_""A1*iaaCH*f=lfjC`^"+AT7B+@3#"O4G?sU*BB=t?&I2QSS9KmC9AqN%bOueAPOMVIU$anA6e0kak]bAX#mM?Qp&V$q7G^jjc"\usA(bb]D8/)6Ze=K.mQ&gs8rOYg/\qXCX'@PHW3=gcTCgU9OQ@5MHadH`FX:90Jp#RR=6c9e#V0VQOjWn>)*@\0;1e.5>Z@H4NB\3Ue`%T,ljRNB(GXhs1al&Pe0/fJlo<k,IN6srQ%B>!fIA]_KcXK8g>FPD#nWnb!/J_h*fi#nW*NZL.?-!rZb&OV*"!Y4R0Kt#dLVSOrm>PL*CnM-l_L%N`_E&C[%b=L(lG`lW;sPaQ7?=;3XhSX$rM/;"R6c<F#]g*E+fkm&6#(Gu'K)m-bg2,jZChrH@iOc^9r9o<&`gMid$LpF%I6`#XXGHc<^E44O3GBVSY$-ng<%;TMibhX%663+$,GY@8GQni>_sJeV[bnpjZf>]hjA6;h_>Z!%JoQ,eCfeNU/s:_A+[OGBt/puaU3\q;kIusj<$nd$nH`=XT*Oo9Q7=_I0TFkd6'(Nk=,!TB`;(kL4A1Qi_MF.$X!~>endstream
+endobj
+% 'R14': class PDFStream 
+14 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 1117 >>
+stream
+Gasan;/_pp&:T\)s"MU/paVU3`Y_?cV,k:n/EN[#b=`p90GlEeQePg*jPP/nf7kWl9k,UVcbOqc2rDhK&CMqHs,.o5k8`>a7hEY$<tHZD!r3<'Q![kqIsL!^0glo"i[@?Y0a^=(pI'p!aKcMc0SFfYZ`jDa`;b:sL)c2,Dgc+-hYN^+_KZOaLttO,CU(cA+o`)D2suC/QPU:#lX1%`C-d!*'tl=.@aGD<*0t(tQaBqtK8ea#8E_7Dq[?L20uJ9\]mqMRe1q4mqZIQ+YSU)C't!m=2f`\!oerJX(RT)99;boNQ@;kRO`<f*o#=<@Enqs$R,rI#^ks_NBFXS<C*Cb9)$O#!co1X>kR>E^C',0)8efk+aA4W*"RPuZL7KMkUp.NJ/K"B7@K7>RV(2<^8o'G<B'tr&d*+dIU]`LsPpQFXdXusJ3>kZKZN-Z^[RM`W;3k>$SU0?9jaNKiB_a4\HriJt[HN-[CFBmp>=omX^3<YbQbAu=AGVl65'CdA1q'4j@,""8TP>`U<,JZ;aJko^-#*sJPj?82+AGXKR>Y)$*;Zg*4WfRMRZ^X@'6n<CY/SO)YB@1Rl,GP+h?c?mCC*Rs;NIC?U1b"ZA/-Xj4m95<c4<iK8E4&=@0<>Q(HPa6$O02BE[:0R2i`<0C5a$9D_4!$$.lD<aW.,E&3&U*_e3/h)&;%W\2q]N2:d4A?+"GIi<ltnLVW8Os8)DAG[ZbW0a_u63b`*6nN;]h`L?`W*XHl0B(`TL.bN+@PQNtIPTPL0n)c0a*a.l1hj.e-E8\k&>*9Aj4*X_tTK!8!Bq$b<=B5kK,_ra$ou,"al9$VQLP@)%)?m"UJeJkD(d`FKMhd$6_a$WjWh/#5Uc.^clqXZ%Gu*(80+241Y"."iD<[S!%$tMJ7D&ue-0^[i3Rb11E:p71;)5-NWAEd:QZG-!8=if+Xe"g&kes8B2jDXj7Uq6Bd"Q1QcP);i8['+hVAYprdmTC2'L]][%(tN_#eCak_!AIaDq$&<R+An,$V;,8cJmijR&2!S%G%od:N6-S"c(VsRr^Et0[qYYQR$@c#6Lh#SgjF#GRDe-S3#@6ErQ=ohj,O8S^o&:GE=]1mHpN:3F&Jdi:>k4he?#d~>endstream
+endobj
+% 'R15': class PDFStream 
+15 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 3689 >>
+stream
+Gau`VD3*G]&cNgos'_"<W)GZ:bO7(;!kmnOY\fia2$O*rqh:>LRu&C?UpM*(f6;u!$Y@Melj_Bi8\?RB*6p\<bep-%(u`6Dq(mg-IU9ofG<Ye3=Du$JH;dq\KjWFb?[R.p_E8ci^SGLPhj]tYn:=rjj%m\OE]Jp:BE[W<#64Mng[T4^\:ZZj)19Lo`o2pUi=D^R$9iO&hC!N)`V_Tp5Jd1lB#<G4^.;Y?nn'R_9Q6Qe!b\$L@o+./(gG/Ubb2pcjXnl-o42C'W*R<B&WFi%TC+&acct%,AGfiKkO;4nRcAne:RS8:77W+1hQl!_g35^PaN1GA2X>ePON8f2O'HNj'Z$!Sp7V!$7d*#)/27+1,_R0)Oi_qg(WiSi^=%?SP0^=,D+e:%cd=*"*oC>@CqB*_[A1CRA2]lZ]?8In)nnQ1B!]UZgdl;ZHrfX;Z)>^,2J'?qDln*]%.59<r!B[Bd%I^m]*6F]R=mqhGm8;I:T?)Z&shX:73GUOeI^.kb=&W<OVt'Q";kZc<t3dJ5`bqSIPGNPc!X1/Tr1<"2b^oj:-N[Si,A<BY;=D4f?*YOKI?c+29,*o&0R,m+'MGo`7.*5#BTsHXd(AJR<[f.E!W75-lSb(7K_sbSD;%?">#*5LQHFC_F$TgkWIKZ'0`Z'9pJ9]E@MPap]^Mi16uJ$W)./LF-$]rcl<WjFue;s_HZ,a_)m[[_cT?4CYAmrST=FlX#GCN'N]e6e^+SSP1,p%:7#C<e&3u0U3Oo""(?IW%;)$!%-%JYLs\LN'!X\In-1]n>X,On$3Hf2Ca1-d*FPpY$sW@'FK!4I`GQ1s"7GP=r+i]L&$I']P8>9ob&YGP:2Dgn@=D3`WCJU/)XYAe#7ObJ&IIm&[Pn&J>>JssOobE4M55;@04K_>XHsQ6[Z>U$*Op+E+ZO1P^nLtF$4$mUn2gtDZ/'H>SJ[c31(:Q#PXl6Q[OfK^\At!*G"A2eX9N<alW"?Q_Bb0R5#3qp6J0Ed_/F_`$mrLK4ALm0j`g#93smdNKsqsP%,*VHn;^omLB`7<6l!JjQfm?6:AgU^FiCUsF;`-6@i1?M^Z7K`pbCa31f]]Ic@!d>r#d4Q2Nr7I#>rBB,PFjq=bJ]mes-[8!(Z)I)?3;5*N(;[KE*E*6?XI`.?gbAA2:;s"#CK\i?F>MS2<H3O1^%X@NfSD]s\-'"_Qjbneta'3r])IOZ0"ar#;X&K>b!nJeAQL6N_%,XL=/RE>nAN3$R5#aC%0i!MZ0b"1kDM:X)i!J5l&tf`\<<Q=0M:.*LaI@M^s,gKClB2+j/Y+?32t"/\cs0nk!R@tD\bSn[_S;f*_[YT9V7clsX!\kY^&,)CNQQ_BB!N`$]m9RV'd)bZ-4ihT5.%&[eS@T<t>-CJ.dUKA/q>p*+NME&n:GUgk2$ggb'Mpae2+B*o?#"9AD9Ug!Gn;Bu%h@W\A@?Y7B<b3Em7^QuW9-':ig:4Es_.i_E(X>F;7lIaL4H3HNJn'rh;n;!lB20FW)=<P8+`f,^);e"3&G^;&b\CBUPcRN!Ar:1j]8/iVUlZsGI3$QXU='`1]3cOJbbVZ!7,3K.N8fD?1+WX!e.YDBpl=OJN=WoD#=X%sHQiS60bE%SMINk*m6mJ30nkep9Bs_BI)sS$^*+7c_BCt4$MNTd.upmG<*)$:'PS04?G!f[Ub^]e-%^b?&mhYED%mC(7c^iq:C*JTHiZlC5U:ilGFOPh`)UT$e>B0Q-f]n>7Wgb`2e;8k2.)B`<lPoIm?da5\!kTG<3/<Q?_BDAVmNa7Se?X1=@*``:M5np_l?m,WEehn.?qn9,)pD@cq,YPFhT:+,m_6=P_\sIM)AK[Wa)HrgqY(V]!>pe3u[XHM[.8:/32YJP)KiC&:*adF!4U[S\JL%KLV;>\qG-KN%:X9b=ORk==S3Tguc*Yas6Nk=%XBfC\R9qgpYR436E/=aZ!eZ;s(L`%N1+?2!'&g\.2"d6$:_J-Q6.pc=nOoN)s0hg,.7>%"jki;G:b_Rc]pS6CDb2A[\;MOII0OMZ@j\5BN#OP[sf[UN<f)/L&;nj3TF`hBr[$7-(hW5IedZA;!QrUYkT<a-EnaPFo*l6_<9O:O<]?*O[]88pJ4AN)A_/Fj/MYbkuQD_Om@O0X-m3ct_F:J]>0]6S0XX;ac`#kf642!MG&bMi>opO?X)YM(X08:95GciCpc7M;L6h>(n+>$c5(rZ_3kXU+Xp@=qVc<U?jf+6fJka:.\I39oQf8)#SUQYD:`Irb:2/gsotRIPFPK9&W8UR1tr'Uts9uI3Rdu;11Cl_G,F4=->q;'Q6(+6'$Y$eO4D"3J6`H$<596$VXejQG0Yu;Jj]]^qU(NY%dID:5j]go/ehRGW#.0Q%k\[]kOef2d7o8<ZHN?^,5SMZUKe*R>c#o.;NoVE=<XO1"9[Bc8M#UoDsM4@^^H)8.#IX)qH!28rB5%iJ>m]`NET,\#TUD\iJ.(im``!UY-'A@W<r[%/-]"*GDFX18e"DI57$6)uV]Tds%k'?#pP5ac&<Kn'Qfe'!/!?4$M4rH&6=X*Ti)>'U!e(L)PP9FqOCP0Y9-`=`)LM>ao=WDT:+s5lHsgquaF>;\J?83R=8ZaZ_=4X\%OG@*_C0@1Ic3Jp5.idBhALDeTI.LMo^G`99/@K1^8*OL6q*/r1$f4F1$5`qN!*M>^(8$$EJOkSf^YbiLV+%?"*2O9t=DVu[!K)D@(6hYB>do^BQ3C#='H7ij(YE+A#/,!00=TaPWN;]C8jV[d9,H<tZhT>(<Gm<NWF-m(F*O2Or_Q9C\JgXqkC:Ge;8QI(,!\K^6CeSoo-TP+kS<YVDmB*rrmP3b4%qY2DqR$HI(9a<bN]=^,j)S$)^BH2\$R]*n1`)l9AB30Y*R]oM!e31o(ou;6^/8kE`95egM2Q!N(omr+V-pH*]<YKC4?7[ETC1D8J;U_8FpP!NtV7L-eBl`'1k9V#=GcO<"$^O+diWE40:?6XhW[NB<92.<PU8&@Jk9Q.)R3Vf-'S?BE%6XAMX>gSVFK!ifP[%eGYO5Pbl2C9CC,M')fW.ZRPIW';qketmh2_;jcBC!;PT[N5)>1lc$ZJV[S[^87Z3sm[?g&e_X7B6eaXpG^::hc+k0%Bp3;hI824:YFbNj%ucDO<^TlTS^H5*Hg.8dOI;4Sf0QL.O.iJQ3')lk&Zf(Y8![=oX,l(`+5PBda<`thU-ZK^.U"UOklhE7Q4:$dCJKb?2SDA63pU1/Q+c*(mJIA)oE*A3QA7012f#]bfGPg@6Tkp(!_']#tcGl9]82e\iD)[gDdd!):r$/*c8%FClM\9E""eHO5t'c1r!6ti0`T\n!4e2M-m9J&2=?#>QrS[%gbUNrOhlt>p\Q1$='d:@]id$V9924eeS[bu/_hY;S9;7BBp,2'-Qj-XpnK3E/e/LPZ\^[$nmiu!6JiRk.*)Pt5a^[jko]n9Hr)(48#kZF32ig_MmKtf9:L?6P!K8]K#cTGmL1p,SLct;m\*B"`%nf3(&%%Abb*LsRnV*99Ne)PPQgDcqQ7(D%'>X$Q0DNCm\[B27Rpji6Z:T]H.and#g\i[B\GGK-Ci7>\_gQ-1OWS\/8c?B?(bM>F[C21IrWghbgEm?tKGL^OYUrFTQc7US_o:;>!G@8]SO./,e1iIiuRHOS5Q(mRZSU9OFAtJ;UoAULX;[7&DFQrmsW<97P#%#%=+0sU;@/~>endstream
+endobj
+% 'R16': class PDFOutlines 
+16 0 obj
+<< /Count 0
+ /Type /Outlines >>
+endobj
+xref
+0 17
+0000000000 65535 f
+0000000113 00000 n
+0000000233 00000 n
+0000000398 00000 n
+0000000587 00000 n
+0000000752 00000 n
+0000001021 00000 n
+0000001290 00000 n
+0000001559 00000 n
+0000001828 00000 n
+0000001965 00000 n
+0000002236 00000 n
+0000002367 00000 n
+0000005557 00000 n
+0000006890 00000 n
+0000008150 00000 n
+0000011984 00000 n
+trailer
+<< /ID 
+ % ReportLab generated PDF document -- digest (http://www.reportlab.com) 
+ [(K\0248\366\245\306\327\220"\3575\260a\241\336\257) (K\0248\366\245\306\327\220"\3575\260a\241\336\257)] 
+
+ /Info 10 0 R
+ /Root 9 0 R
+ /Size 17 >>
+startxref
+12036
+%%EOF

--- a/src/z3c/rml/tests/module.py
+++ b/src/z3c/rml/tests/module.py
@@ -18,7 +18,7 @@ import reportlab.lib.styles
 import reportlab.graphics.widgets.markers
 from reportlab.graphics import renderPDF, shapes
 from reportlab.lib import colors
-from z3c.rml import interfaces, attr
+from z3c.rml import attr, interfaces, SampleStyleSheet
 
 def myPreformatted(params):
     return reportlab.platypus.Preformatted('''
@@ -32,7 +32,7 @@ def myPreformatted(params):
         plugin. Hey, this is a long text from a plugin. Hey, this is a long
         text from a plugin. Hey, this is a long text from a plugin. Hey, this
         is a long text from a plugin.''',
-        reportlab.lib.styles.getSampleStyleSheet()['Normal'])
+        SampleStyleSheet['Normal'])
 
 class LinkURL(reportlab.platypus.flowables.Flowable):
     def __init__(self, link):
@@ -49,7 +49,7 @@ def linkURL(params):
     params = eval(params)
     return (
         reportlab.platypus.Paragraph(
-            params[0], reportlab.lib.styles.getSampleStyleSheet()['Normal']),
+            params[0], SampleStyleSheet['Normal']),
         LinkURL(*params))
 
 class IMarker(interfaces.IRMLDirectiveSignature):


### PR DESCRIPTION
1) One of the expected PDFs went missing again in cc4bca2 so I added that.

2) I added a `.gitattributes` so hopefully the PDFs don't get messed up again in transmission.

3) Made it so that `getSampleStyleSheet` is only called once. Apparently it was called for every `para`.

4) Gave `processStyle` on `Paragraph` a similar tweak as the one on `TableCell`.

5) `getManager` no longer calls `interface.providedBy` (which does a heap of checks) and instead just looks in the dictionary. Removing the check entirely speeds things up even more (especially for `para`) and all tests still pass but I didn't go that far since I don't fully understand its purpose.

6) `getAttributeValues` now caches a signature's fields. Further improvements can be made by not doing `attr.bind(self).get()` if the attribute doesn't exist, but that causes a whole heap of issues with missing and default values. It's doable but will require small changes all over the place.

7) Unless the document is in debug mode turn off `rl_config.shapeChecking` to improve performance. Shape checking appears to be some kind of method of disallowing invalid attributes on objects in ReportLab, but since it does so many checks on every attribute that's set it slows things down quite a lot. I don't think someone using RML could even set invalid attributes anyway?

8) `rl_fix.resetFonts` no longer registers the fonts on every call. On Windows this meant the entire fonts directory and on all platforms it meant the Vera fonts. A huge improvement on Windows and a small improvement everywhere else. This could cause an issue on Windows if someone uses a font in their system directory but didn't register it in the RML.

9) `etree.tounicode` in the XML attributes is pretty slow. Adding `pretty_print=False` sped it up a little bit.

Even running `bin/test` is faster.

Without the windows font fix: 62.052s
With Windows font fix: 9.101s
With all fixes: 6.285s
