### PR TITLE
Replace pyPdf library with PyPDF2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 2.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Switch from ``pyPdf`` to the newer ``PyPDF2`` library.
 
 
 2.3.0 (2013-09-03)

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup (
     install_requires=[
         'Pygments',
         'lxml',
-        'pyPdf',
+        'PyPDF2',
         'reportlab',
         'setuptools',
         'svg2rlg',
@@ -95,4 +95,3 @@ setup (
     include_package_data=True,
     zip_safe=False,
     )
-

--- a/src/z3c/rml/page.py
+++ b/src/z3c/rml/page.py
@@ -17,12 +17,12 @@ import cStringIO
 from z3c.rml import attr, directive, interfaces
 
 try:
-    import pyPdf
-    from pyPdf.generic import NameObject
+    import PyPDF2
+    from PyPDF2.generic import NameObject
 except ImportError:
     # We don't want to require pyPdf, if you do not want to use the features
     # in this module.
-    pyPdf = None
+    PyPDF2 = None
 
 class MergePostProcessor(object):
 
@@ -30,15 +30,15 @@ class MergePostProcessor(object):
         self.operations = {}
 
     def process(self, inputFile1):
-        input1 = pyPdf.PdfFileReader(inputFile1)
-        output = pyPdf.PdfFileWriter()
+        input1 = PyPDF2.PdfFileReader(inputFile1)
+        output = PyPDF2.PdfFileWriter()
         output._info.getObject().update(input1.documentInfo)
         output._root.getObject()[NameObject("/Outlines")] = (
             output._addObject(input1.trailer["/Root"]["/Outlines"]))
         for (num, page) in enumerate(input1.pages):
             if num in self.operations:
                 for mergeFile, mergeNumber in self.operations[num]:
-                    merger = pyPdf.PdfFileReader(mergeFile)
+                    merger = PyPDF2.PdfFileReader(mergeFile)
                     mergerPage = merger.getPage(mergeNumber)
                     mergerPage.mergePage(page)
                     page = mergerPage
@@ -76,7 +76,7 @@ class MergePage(directive.RMLDirective):
         return procs['MERGE']
 
     def process(self):
-        if pyPdf is None:
+        if PyPDF2 is None:
             raise Exception(
                 'pyPdf is not installed, so this feature is not available.')
         inputFile, inPage = self.getAttributeValues(valuesOnly=True)

--- a/src/z3c/rml/pdfinclude.py
+++ b/src/z3c/rml/pdfinclude.py
@@ -15,9 +15,9 @@
 """
 __docformat__ = "reStructuredText"
 try:
-    import pyPdf
+    import PyPDF2
 except ImportError:
-    pyPdf = None
+    PyPDF2 = None
 from reportlab.platypus import flowables
 
 from z3c.rml import attr, flowable, interfaces, occurence, page
@@ -30,7 +30,7 @@ class IncludePdfPagesFlowable(flowables.Flowable):
         self.pdf_file = pdf_file
         self.proc = mergeprocessor
 
-        pdf = pyPdf.PdfFileReader(pdf_file)
+        pdf = PyPDF2.PdfFileReader(pdf_file)
         self.num_pages = pdf.getNumPages()
         self.pages = pages if pages else range(1, self.num_pages+1)
 
@@ -96,9 +96,9 @@ class IncludePdfPages(flowable.Flowable):
         return procs['MERGE']
 
     def process(self):
-        if pyPdf is None:
+        if PyPDF2 is None:
             raise Exception(
-                'pyPdf is not installed, so this feature is not available.')
+                'PyPDF2 is not installed, so this feature is not available.')
         args = dict(self.getAttributeValues())
         proc = self.getProcessor()
         self.parent.flow.append(

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     Pygments
     coverage
     lxml
-    pyPdf
+    PyPDF2
     reportlab
     setuptools
     svg2rlg


### PR DESCRIPTION
The pyPdf library is no longer being maintained, perhaps we should upgrade it to the PyPDF2 library (https://github.com/mstamy2/PyPDF2/).

Since PyPDF2 is a superset of pyPdf, it should just work out of the box.
