### PR TITLE
Compatible with newer PyPDF2 versions

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -82,7 +82,6 @@ eggs = ${test:eggs}
 
 [versions]
 Pillow = 2.5.1
-PyPDF2 = 1.21
 lxml = 3.3.5
 reportlab = 3.1.8
 zope.interface = 4.1.1

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,7 @@ setup (
     install_requires=[
         'Pygments',
         'lxml',
-         # XXX: PyPDF2 1.22 does not work.
-        'PyPDF2==1.21',
+        'PyPDF2>=1.21',
         'reportlab>=3.0',
         'setuptools',
         'svg2rlg',

--- a/src/z3c/rml/page.py
+++ b/src/z3c/rml/page.py
@@ -24,6 +24,7 @@ except ImportError:
     # in this module.
     PyPDF2 = None
 
+
 class MergePostProcessor(object):
 
     def __init__(self):
@@ -32,9 +33,16 @@ class MergePostProcessor(object):
     def process(self, inputFile1):
         input1 = PyPDF2.PdfFileReader(inputFile1)
         output = PyPDF2.PdfFileWriter()
+        # TODO: Do not access protected classes
         output._info.getObject().update(input1.documentInfo)
-        output._root.getObject()[NameObject("/Outlines")] = (
-            output._addObject(input1.trailer["/Root"]["/Outlines"]))
+        if output._root:
+            # Backwards-compatible with PyPDF2 version 1.21
+            output._root.getObject()[NameObject("/Outlines")] = (
+                output._addObject(input1.trailer["/Root"]["/Outlines"]))
+        else:
+            # Compatible with PyPDF2 version 1.22+
+            output._root_object[NameObject("/Outlines")] = (
+                output._addObject(input1.trailer["/Root"]["/Outlines"]))
         for (num, page) in enumerate(input1.pages):
             if num in self.operations:
                 for mergeFile, mergeNumber in self.operations[num]:


### PR DESCRIPTION
Issue was z3c.rml accessing a protected property of PyPDF class whose behavior had changed between versions.

Wasn't sure about buildout.cfg line 85.

Also wasn't sure if we needed page.py lines 36-45 at all, since the tests all passed in versions 1.21, 1.22, and 1.23 with those files completely deleted. Decided to play it safe and leave them in there.
