### PR TITLE
Fix "Unresolved bookmark" issue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ CHANGES
 ------------------
 
 - Support for python 3.3 and 3.4
+- Fix "Unresolved bookmark" issue
 
 
 2.9.3 (2015-09-18)


### PR DESCRIPTION
When including other PDFs into the document with nested outline, previous implementation cause "Unresolved bookmark" error if pdf was inserted between parent and child outline bookmarks.
