### PR TITLE
Use SVG viewBox x,y properly

### DIFF
--- a/src/z3c/rml/svg2rlg.py
+++ b/src/z3c/rml/svg2rlg.py
@@ -842,7 +842,7 @@ class Renderer:
 
             height = self.drawing.height
             self.mainGroup.scale(1, -1)
-            self.mainGroup.translate(0, -height)
+            self.mainGroup.translate(-float(minx), -height-float(miny))
             self.drawing.add(self.mainGroup)
 
             self.level -= 1


### PR DESCRIPTION
This should fix rendering SVGs not showing up properly translated when the viewBox is not anchored at 0,0