### PR TITLE
Fix FutureWarning: split() requires a non-empty pattern match.

### DIFF
--- a/src/z3c/rml/attr.py
+++ b/src/z3c/rml/attr.py
@@ -182,7 +182,7 @@ class StringOrInt(RMLAttribute):
 class Sequence(RMLAttribute, zope.schema._field.AbstractCollection):
     """A list of values of a specified type."""
 
-    splitre = re.compile('[ \t\n,;]*')
+    splitre = re.compile('[ \t\n,;]+')
 
     def __init__(self, splitre=None, *args, **kw):
         super(Sequence, self).__init__(*args, **kw)


### PR DESCRIPTION
On Python 3.5.2 you get the following warning:

```
>>> re.compile("[ \t\n,;]+").split("test")
['test']

>>> re.compile("[ \t\n,;]*").split("test")
__main__:1: FutureWarning: split() requires a non-empty pattern match.
['test']
```
