### PR TITLE
Fix Travis + add Py35 to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,26 @@
 language: python
 sudo: false
-# Get japanese minch fonts. Don't use debian-sid because it frequently breaks
+# Get japanese minch fonts
 addons:
     apt:
         packages:
         - fonts-takao-mincho
-# Python 3.5 isn't currently installed by default
+# Python 3.5 isn't currently installed by default on Travis so it must be listed here.
+# However this causes Travis to detect all environments as 3.5 so to fix that we need
+# to list all versions here and use tox-travis insead of TOXENV.
 python:
+    - "2.7"
+    - "3.3"
+    - "3.4"
     - "3.5"
-# The version of GS in the repos is too old
+# The version of GS in the repos is too old and using debian-sid often breaks
 before_install:
     - wget https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs920/ghostscript-9.20-linux-x86_64.tgz
     - tar -xvf ghostscript-9.20-linux-x86_64.tgz
     - mv ghostscript-9.20-linux-x86_64/gs-920-linux_x86_64 ghostscript-9.20-linux-x86_64/gs
     - export PATH=$PWD/ghostscript-9.20-linux-x86_64:$PATH
-env:
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=py35
 install:
-    - travis_retry pip install tox
+    - travis_retry pip install tox-travis
 script:
     - tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: python
 sudo: false
-# We need ghostscript at least 9.15 and japanese minch fonts
+# Get japanese minch fonts. Don't use debian-sid because it frequently breaks
 addons:
     apt:
         packages:
-        - ghostscript
         - fonts-takao-mincho
+# Python 3.5 isn't currently installed by default
+python:
+    - "3.5"
+# The version of GS in the repos is too old
+before_install:
+    - wget http://downloads.ghostscript.com/public/binaries/ghostscript-9.15-linux-x86_64.tgz
+    - tar -xvf ghostscript-9.15-linux-x86_64.tgz
+    - mv ghostscript-9.15-linux-x86_64/gs-915-linux_x86_64 ghostscript-9.15-linux-x86_64/gs
+    - export PATH=$PWD/ghostscript-9.15-linux-x86_64:$PATH
 env:
     - TOXENV=py27
     - TOXENV=py33

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: python
 sudo: false
-before_install:
-    - sudo apt-get update
 # We need ghostscript at least 9.15 and japanese minch fonts
 addons:
     apt:
-        sources:
-        - debian-sid
         packages:
         - ghostscript
         - fonts-takao-mincho

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
     - "3.5"
 # The version of GS in the repos is too old
 before_install:
-    - wget http://downloads.ghostscript.com/public/binaries/ghostscript-9.20-linux-x86_64.tgz
+    - wget https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs920/ghostscript-9.20-linux-x86_64.tgz
     - tar -xvf ghostscript-9.20-linux-x86_64.tgz
     - mv ghostscript-9.20-linux-x86_64/gs-920-linux_x86_64 ghostscript-9.20-linux-x86_64/gs
     - export PATH=$PWD/ghostscript-9.20-linux-x86_64:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ python:
     - "3.5"
 # The version of GS in the repos is too old
 before_install:
-    - wget http://downloads.ghostscript.com/public/binaries/ghostscript-9.15-linux-x86_64.tgz
-    - tar -xvf ghostscript-9.15-linux-x86_64.tgz
-    - mv ghostscript-9.15-linux-x86_64/gs-915-linux_x86_64 ghostscript-9.15-linux-x86_64/gs
-    - export PATH=$PWD/ghostscript-9.15-linux-x86_64:$PATH
+    - wget http://downloads.ghostscript.com/public/binaries/ghostscript-9.20-linux-x86_64.tgz
+    - tar -xvf ghostscript-9.20-linux-x86_64.tgz
+    - mv ghostscript-9.20-linux-x86_64/gs-920-linux_x86_64 ghostscript-9.20-linux-x86_64/gs
+    - export PATH=$PWD/ghostscript-9.20-linux-x86_64:$PATH
 env:
     - TOXENV=py27
     - TOXENV=py33

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - TOXENV=py27
     - TOXENV=py33
     - TOXENV=py34
+    - TOXENV=py35
 install:
     - travis_retry pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 sudo: false
+before_install:
+    - sudo apt-get update
 # We need ghostscript at least 9.15 and japanese minch fonts
 addons:
     apt:

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup (
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
         'Natural Language :: English',
         'Operating System :: OS Independent'],

--- a/src/z3c/rml/attr.py
+++ b/src/z3c/rml/attr.py
@@ -182,7 +182,7 @@ class StringOrInt(RMLAttribute):
 class Sequence(RMLAttribute, zope.schema._field.AbstractCollection):
     """A list of values of a specified type."""
 
-    splitre = re.compile('[ \t\n,;]*')
+    splitre = re.compile('[ \t\n,;]+')
 
     def __init__(self, splitre=None, *args, **kw):
         super(Sequence, self).__init__(*args, **kw)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34
+envlist = py27,py33,py34,py35
 
 [testenv]
 commands =


### PR DESCRIPTION
This was originally only meant to add Python 3.5 to tox and travis but apparently debian-sid is broken again: https://travis-ci.org/kylemacfarlane/z3c.rml/jobs/168428564

To get around this I had to remove debian-sid and go back to installing gs manually.

This also includes #47 which is needed for 3.5.
