### PR TITLE
Fast PDF merging

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -22,7 +22,7 @@ initialization =
   # that cannot be run with bin/coverage run bin/test, or even
   # bin/python bin/test
   import coverage, atexit, sys
-  c = coverage.coverage(data_file='../../../.coverage',
+  c = coverage.coverage(data_file='${buildout:directory}/.coverage',
                         branch=True,
                         cover_pylib=False,
                         source=['z3c.rml'])

--- a/setup.py
+++ b/setup.py
@@ -77,9 +77,10 @@ setup (
             'zope.pagetemplate']
         ),
     install_requires=[
-        'Pygments',
-        'lxml',
         'PyPDF2>=1.25.1',
+        'Pygments',
+        'backports.tempfile',
+        'lxml',
         'reportlab>=3.1.44',
         'setuptools',
         'six',

--- a/src/z3c/rml/attr.py
+++ b/src/z3c/rml/attr.py
@@ -211,7 +211,7 @@ class IntegerSequence(Sequence):
     def fromUnicode(self, ustr):
         ustr = ustr.strip()
         pieces = self.splitre.split(ustr)
-        numbers = set([])
+        numbers = []
         for piece in pieces:
             # Ignore empty pieces.
             if not piece:
@@ -220,10 +220,10 @@ class IntegerSequence(Sequence):
             if '-' in piece:
                 start, end = piece.split('-')
                 # Make range lower and upper bound inclusive.
-                numbers.update(range(int(start), int(end)+1))
+                numbers.append((int(start), int(end)+1))
                 continue
             # The piece is just a number
-            numbers.add(int(piece))
+            numbers.append((int(piece), int(piece)+1))
         return list(numbers)
 
 class Choice(BaseChoice):

--- a/src/z3c/rml/pdfinclude.py
+++ b/src/z3c/rml/pdfinclude.py
@@ -213,7 +213,7 @@ class IIncludePdfPages(interfaces.IRMLDirectiveSignature):
 class IncludePdfPages(flowable.Flowable):
     signature = IIncludePdfPages
 
-    ConcatenationPostProcessorFactory = ConcatenationPostProcessor
+    ConcatenationPostProcessorFactory = PdfTkConcatenationPostProcessor
 
     def getProcessor(self):
         manager = attr.getManager(self, interfaces.IPostProcessorManager)

--- a/src/z3c/rml/pdfinclude.py
+++ b/src/z3c/rml/pdfinclude.py
@@ -76,21 +76,19 @@ class IncludePdfPagesFlowable(flowables.Flowable):
         pages = self.pages
         if not pages:
             pdf = PyPDF2.PdfFileReader(self.pdf_file, strict=STRICT)
-            num_pages = pdf.getNumPages()
-            pages = range(num_pages)
-        else:
-            num_pages = len(pages)
+            pages = [(1, pdf.getNumPages()+1)]
+
+        num_pages = sum(pr[1]-pr[0] for pr in pages)
 
         start_page = self.canv.getPageNumber()
         self.proc.operations.append(
-            (start_page, self.pdf_file, self.pages, num_pages))
-
-        result = []
+            (start_page, self.pdf_file, pages, num_pages))
 
         # Insert blank pages instead of pdf for now, to correctly number the
         # pages. We will replace these blank pages with included PDF in
         # ConcatenationPostProcessor.
-        for i in pages:
+        result = []
+        for i in range(num_pages):
             # Add empty spacer so platypus don't complain about too many empty
             # pages
             result.append(flowables.Spacer(0, 0))

--- a/versions.cfg
+++ b/versions.cfg
@@ -114,3 +114,13 @@ zope.testrunner = 4.4.10
 # Required by:
 # zope.pagetemplate==4.2.1
 zope.traversing = 4.0.0
+
+# Added by buildout at 2017-01-08 13:11:37.585090
+
+# Required by:
+# z3c.rml==3.1.1.dev0
+backports.tempfile = 1.0rc1
+
+# Required by:
+# backports.tempfile==1.0rc1
+backports.weakref = 1.0rc1


### PR DESCRIPTION
Improved page range handling when including PDFs. This gives a 5x speedup of including files with ranges.

Provide an alternative concatenation post processor based on pdftk, which is about 10x faster.