### PR TITLE
svg2rml not working when viewBox not present

### DIFF
--- a/src/z3c/rml/svg2rlg.py
+++ b/src/z3c/rml/svg2rlg.py
@@ -828,7 +828,8 @@ class Renderer:
                     minx, miny, width, height = node.get("viewBox").split()
                 except ValueError:
                     raise SVGError("viewBox values not valid")
-
+            else:
+                minx, miny = 0, 0
             if width.endswith('%') and height.endswith('%'):
                 # handle relative size
                 wscale = parseLength(width) / 100.


### PR DESCRIPTION
A missing else when checking `viewBox` leaves `minx`, `miny`, undefined (and used later on).