### PR TITLE
Fix for breaking change from pikepdf 3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 4.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixes breaking change in `pikepdf` 3.0.
 
 
 4.1.2 (2020-12-14)

--- a/src/z3c/rml/page.py
+++ b/src/z3c/rml/page.py
@@ -36,7 +36,7 @@ def mergePage(layerPage, mainPage, pdf, name) -> None:
     mainPage.Resources["/XObject"][name] = contentsForName
     # Use the MediaBox from the merged page
     mainPage.MediaBox = layerPage.MediaBox
-    mainPage.page_contents_add(
+    mainPage.contents_add(
         contents=pikepdf.Stream(pdf, newContents),
         prepend=True
     )


### PR DESCRIPTION
`page_contents_add` was renamed to `contents_add`