### PR TITLE
Support for the ReportLab BlockTable split options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ CHANGES
 4.3.1 (unreleased)
 ------------------
 
+- Add support for the splitByRow and splitInRow arguments to BlockTable.
+
 - Add ``rlPyCairo`` as install requirement as ``reportlab >= 4.0`` needs that library.
   (`#117 <https://github.com/zopefoundation/z3c.rml/issues/117>_`)
 

--- a/src/z3c/rml/flowable.py
+++ b/src/z3c/rml/flowable.py
@@ -770,6 +770,18 @@ class IBlockTable(interfaces.IRMLDirectiveSignature):
         choices=interfaces.ALIGN_TEXT_CHOICES,
         required=False)
 
+    splitByRow = attr.Boolean(
+        title='Split table between rows',
+        description='Allow tables to span multiple pages',
+        default=True,
+        required=False)
+
+    splitInRow = attr.Boolean(
+        title='Split table in rows',
+        description='Allow table rows to span multiple pages',
+        default=False,
+        required=False)
+
 
 class BlockTable(Flowable):
     signature = IBlockTable

--- a/src/z3c/rml/rml.dtd
+++ b/src/z3c/rml/rml.dtd
@@ -379,6 +379,7 @@
 <!ATTLIST image showBoundary CDATA #IMPLIED>
 <!ATTLIST image preserveAspectRatio CDATA #IMPLIED>
 <!ATTLIST image mask CDATA #IMPLIED>
+<!ATTLIST image anchor (nw | n | ne | w | c | e | sw | s | se) #IMPLIED>
 
 <!ELEMENT place EMPTY>
 <!ATTLIST place x CDATA #REQUIRED>
@@ -1683,6 +1684,8 @@
 <!ATTLIST blockTable colWidths CDATA #IMPLIED>
 <!ATTLIST blockTable repeatRows CDATA #IMPLIED>
 <!ATTLIST blockTable alignment (left | right | center | centre | decimal) #IMPLIED>
+<!ATTLIST blockTable splitByRow CDATA #IMPLIED>
+<!ATTLIST blockTable splitInRow CDATA #IMPLIED>
 
 <!ELEMENT tr (td+)>
 
@@ -1918,7 +1921,7 @@
 <!ATTLIST li bulletFormat CDATA #IMPLIED>
 <!ATTLIST li bulletType (I | i | 1 | A | a | l | L | O | o | R | r | bulletchar | bullet | circle | square | disc | diamond | rarrowhead | diamondwx | sparkle | squarelrs | blackstar) #IMPLIED>
 <!ATTLIST li style CDATA #IMPLIED>
-<!ATTLIST li value (bulletchar | bullet | circle | square | disc | diamond | rarrowhead | diamondwx | sparkle | squarelrs | blackstar) #IMPLIED>
+<!ATTLIST li value CDATA #IMPLIED>
 
 <!ELEMENT includePdfPages EMPTY>
 <!ATTLIST includePdfPages filename CDATA #REQUIRED>

--- a/src/z3c/rml/tests/expected/tag-blockTable-11.pdf
+++ b/src/z3c/rml/tests/expected/tag-blockTable-11.pdf
@@ -1,0 +1,118 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 11 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 10 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 12 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 10 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 13 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 10 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/PageMode /UseNone /Pages 10 0 R /Type /Catalog
+>>
+endobj
+9 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20230823143601-01'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20230823143601-01'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+10 0 obj
+<<
+/Count 3 /Kids [ 5 0 R 6 0 R 7 0 R ] /Type /Pages
+>>
+endobj
+11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1759
+>>
+stream
+Gasao?$"aY&:F5U\4<rj1*S=)b"S]hC#cSbfP/d4H&"pm63;`q530JN`<QEIG*H0?RfX,1`STGQ2(e?t_r%mMqL(^ahptac[(2rX<NTqU6e@g6qm/=P?8Zi4=sFkoLp$=N#jpks?.E_<flY_#IdYCg%:KC?/]1*IB^tCa[/!%HXW6&u)n)"oIfD"tHhm@t9j#bsmH>#J#C6r):H(Ug2'HT'1]9)P"FM<]3PsEnN5q^<1*W@+4L9_C+RWVL+HkP:94jF*)VT6/^ptXP4Cg_'JQT+IAde5`"22qmE\D.75!Ob*5#3";0=&)*2"+"p`q@gjEmS?M-.[/7K%`L.hHFffT"ls\-UqNJTm"AZV&*ZeLP`s'1]>[_jo%0'E1pI_M9[PCcB;^BUa'be.S`.].7R!gHcIU^Vb.k=nJ7N%FeZ8D#86(NJCPmn;!$V"#1\R%.j$*!3cN%QZbd:F>KEuX_D7]1))_i)._<&FFCLo*98PWGmN"emLA4%q4#3;'Ur6]bI)h4XVP<fo]:Yp92)@E=:V$X&#lEQ@5q&V8AaAB@;f,WM.iBI])mSLNaO@$I5,P'(4@8I(TNEtr0:6D5hYFQDibtDJXbWX1*fnbS,RQteelMF1Wfl``AX'.9dFXPZpNM.>m9uUI"'CY,V]cKm-**'u4]>j3?<7rMH?J<aR6mLZ?=3KZ$VEXijlWjeQLu][2j]lWb5PH:$<gEHBqQRB9QR8&Q_osIMjC,+*)`a![;K945bp4,!iC.$:M]1mTN[+kr5IA0^Lpc()T-9Rb]9$!Cb3X_<c"<0Mpom4lb>q$B[@;#-\`g"29?sGo3;`Y8gI!@544^VmSKCe*V@E1M@D05m1_*XOpjFTk`'N.dOrWVk,(C6ArqZ.]i<A`hiK,2`+!f\N44mRd;@8+4#OFX)V!eH`&4k9h%%kc/Ubi6?k:\hCdZG,:+d*M['>ApVYm<KrZ/M?R`6j'c\`1dJo0ium-?QQEh<oj*(d-T#t1I\bdA3tnp)>?Js.K#d0HF>p41E,*EO9S,,3E4'#W2t]Fmd-.!-grG5;NA4bs3l\n$]<+7b-Y_8R0ZUcOHT-"\0hVsH6%L^nV,3W[A4A(XNZ8d=)Y.S46RdHIt/#3fP"Ju8r<2-Ub:lfT;u+B-GeV'#ND"/hnQ^*#AlL>Q^Y4N.up0kK,H>`sD%T<g*.U9e>]($4B7kU`#i>L(bb_=e96V)@lfE9_h<$n%TrXU!M`Z'8kuTnPDt`@213QKS:g6;QJXf$1N*qE?l;OqW7``XZsg[YUVu+rqZ.bk_7GXQjDG"lKouJGp'QMdSiV\?Q!rcEC(;@+G7n:afJ$q7!:U90!0=p<inR%g?a5,$d#LbG?S=lon2mlsrOfK@?5n4D&=kl`D[;.CdEFDl3b`YVn;0l*Uu.9$7"#R:^.j;[?QSRcNZQ?tOseS[_/F_)%aG,0+]7>i`3k$CcB;4GMA0.L*R$"PTNVciR$)\cZej*A9>0+RhnB/5>V'lmH^qHLRILK:gG9i7OA;\_mT.[cGX<('H[@emB2@"(LEiO#J>gJo`-gee9+aYrin,P[c`@ndu'[ZUlXb@*K18_HdXhljXin:CG90%>E@B0kDseRg^i/7(iQEcUF4775t45c*O2Rl`mmP*T9C^)99QQma$0o[Qj-WqW.&.jPB'=r-etN?<sWbQESm3n"1GC3)^[*4C:u^X,B#$8bs,jrRc-Kino5=0#!fE<pOJD5>@n1P/^B!'M"YT!m#e3I%&Xb(d<'8%4G2''*~>endstream
+endobj
+12 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1775
+>>
+stream
+Gat%#?$G$]%"6I*^gjh%BpQMs4D%g0G,OTFlLpd7(l(6gj\hoOpNJo$U`:cM>.9JY&HiBpHNDYR_l""E2]^9f)uBM5:%b#7pJ`fH-#MMebK\#8M`U7<Ra^P6NQkRpKf-KS(sQ[/Cjoj#VT#N'SUK+jCYEkX7pNb@NRDQ<!tDQ4^/[==^"k17k-<M0?.ZQ6=T=(5?YT*^>mb;A0GT#P:EpjfH#!O?h@=uW\W`&42bi-n1f?uIL2UC!oZh5(3\nAl"1KN\7tYgsh)<;[SF#s_V;=+f>-V.5SF*_jWf[B46V90VJHo7V[ed<hK5@'"hNI</m&9<2CoA#b+DAPNdcA[I_DgFY7,7GRTdW>()$.S!E1jRf&6:hBZ;%Af=4'[C*4;:["9^McNJ:bTeL9Tb`HU'#n@_A7dUhGnSal(DPkp7Kog*9*NK[Nj+Ot'CAXp-0n)tlOkNSOJB0A"f-,icD6mO`OgE>CE1_)u%SGu"uUpYf-k"&dZd7JH-G=?H(I(X<D`.WUi.4+AR:b6<*Ai0)ILU:'kE1W@YfBf0#OG)?SeW=WHBn3o;2A0g?8r$[#_<\dY_F_\-D,)8T'gCV5Jc'mm="C;S)"hU`ajUth]VP14EYd-h+8l!SfMnu=X4b`TrVJO>^0d7H7`X[s/P4D=X=RFq=Q?#bFdCWkH%hkShD_(1&.S)fho7#c_rk,=nE:;*Q]^>:WiqiOo18G3fP9LG6(j*^TI:@BOR9eIb28=3r;C=9>2GbaTuHRo&UGC`WqM'X^4Ng3S1c!NRF+HS=p5$db3XpUnKOV2]TUDn%k)25KL1Z5<U5WS*,Dg546Cp0-(tc0PIMcdetNZVe0>(s1q0Jn3['&GQP,REPc%N<FfGUL7r]5jL&<>qTL`Q(,f&5)RdEC,m$"N9$3%X3DD+aB,S4Pmbn?]94-lAqZEYV;Gu6Vu$/7XgI8F<0Y3]EAc>_-2$\X>kW3*EqK1G+;VkWo*@?MO>&a<@jnA+mX55GS`a7CM*a4:7;4btH+h'?">gUWOpm4S3`R5OCr[kO*ca<]SG5XRheI]*d8p#;K,/3qZ?&i%7PI<?%moC_rOeDI5R`1?C2,$@n`RCU]_)7nr^KX`-IAi$:fM;!58Sm`^ee$+SA(8_$pLb6%FK;?28Nf!sO1u8>D]WKdVib4a^4s,LJ;[k)tiq>*0o(Fa>1qi"B+W*h!SIu;TP$:^NIka:u>EUC.21Zf_6"poE.TNj4I5Rim6uI-62F(MuD1MF$1U<R,PTs6T/N:&K1b096aO:FY^jD)u>XCP]EU;r!I&Y#ij&EIEI%?9rGEKu,oKq"t8p/EI'Zu(haIu;opXg:8/B&340T'D]SQaiBdo*)QoTO/61-FDH9E^6.K2tS!oFjiDLsnnWkFh^gh`.9FTgOQi*m&Ig-?qH%=`I7ieG;',PR0.%SI-ePK4AmVaVsQ[orO3_B&NlR'fa`I'HcLNNeSYijT<jPagjo:pT/^UP^<9Jos+lO-qo\3gaT`9p$%\]&"RgM<0T-]8O#WK"k>9Z0@[5>6IY`a$;P>d%0tPhYS8kl:dM;NErrqeq*4_$p<@/+HW!#e*1X6$?iAn:=(B\)8AKJARRXCKkkhhl<R7kP0`-9r97[$bX:"g!MZiW)WHX&Z#Fu@n'D\"uYeLR`C\4UaZqE&I%tLiP*R^#];d9SG0_]/FY+lJ<!07#f#gC@Oa1@O.'OM**-M"*N6a;$AC9'qRIQ6[HnM2"Q<rOutD.f&tkm0E-[oe[Ar,#\EO&PQE\KQ2[,7_P3nK3?OY5e~>endstream
+endobj
+13 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1385
+>>
+stream
+GasaogN)%,&:O:Sm%`='Z6El!c=8M&Rnh[/C,t_o#h-kF!0)p-q`P>Vk/^S5=VeZe/f)(^S7PD6]^#Drp-c[`l0!7JeICmfW4o:7B`EX$pD6UAosjV)U#lf&L2E,k^:Tcf2VG2mEI(",leSO94eH%>E9^5N>`)iVZ8rg0.7cVc8>='.f!_?+4t,0_SlCNr&%)@'q]G(n:38Nd*D!XbSIJ1\'pGO=q%P5GH4W[56OL0?ON^R+iCOp;.iVDod77aVQ7>!C7??H$UTeb3kaaqOMI)(:GsbCDa.uPZD22XiJ>K*@qI+M?nl?=i1HZ#JU)3EqU<h!?E83':jFFH?\f<%0/2XFaRSp<P/qj=+cljq])V[@jApo/]C3bT7<:kVFq!t3j7pJrS0RP12>tIZ.LgE,,-r5DPci$*a.jph\+D-O$*?HXjO'aO='Zf@`d,:J'H-bK.c;sQF#E?562G&t`X]hg-7dLXPY"gf&`tM@J4pX6@34P'78,c&+JHKld$*P)tRVc?tBRB?:&N=SfrVHAZ^V6N6B,,:nlXj(fL%Xlr79I;<;B$WuJVe0MUOoGB"IjL]mol(Fo;)U%-7gC\.Ou@m),;r41kScJ%80aIqc?%_kb$WTZB"5m2"QFUM:0T1V_DRW9'<%J<Xaos?iW0Q$@K.Td0M"hO'3CpgDXYKX.EM8kikMAJcap[4)^]ea%Y]f5q3cjhBO3=AMDBAR!i/_#eOZ"Zs9:>nXM=;lBp9;>;JrckGastp;:#/MNIL.(r"7N4l)\BkfBhn!>Q^=:iQ\AD?VJ"K#"_=/0;@Ak`e7\&!g!Ja?;T+Y+2'I1PPQY'hkEiMR!jU1^gt?Ql.nb[YgI4)<JA@L"5Ar3472!g_ui(V0TNm)f`"ER*:YdL^H-n1APbkYApVBGNZKdCpr6=XmK8'h7Pj(mP<G#G(jW?j9FO?]`?cLBGXpu",(HM/t^UrV$s\j;:2TGld>ru/=k',!9^l,=[PjJNl(+p7Z)"iUb,F@BiAjk,$u]1r&Kc]H>Nd^Q>W9_;i".k^OK8+$YoM>cj'Q"\LX.O5-18%cH'W^`oo#m1#h>`qTL3$cc9'%SbEm%<K9Fh4gkOs`!IOtpZNbt@l;74;<E)c`DNgBQqMZX!Y[8J+J2&!6S<l?*L[[3>X.u*%5R@%L9hLGJr(]HOiicTP=o?HIT(jkS6Sp-K\JK^b5B44.rEEcT)cCBHlV[,6U4D/3i$81r.2mW:C<^Kft5cjJc^>gGp'J*JkXT>:IT.5OM=6):F+_=Sd7crFac5^*WGqCU=\#[GeQ8[o"X\nP0%"sY'-;D2tZP\0R^X=3C])(%a6hQ#KtZ#c8PZ,XIInO=LNH</N-p0ef*M*PukrY1csd>&^"jGq^K;Di]j)!EJ"~>endstream
+endobj
+xref
+0 14
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000336 00000 n 
+0000000448 00000 n 
+0000000653 00000 n 
+0000000858 00000 n 
+0000001063 00000 n 
+0000001132 00000 n 
+0000001415 00000 n 
+0000001487 00000 n 
+0000003338 00000 n 
+0000005205 00000 n 
+trailer
+<<
+/ID 
+[<c4533e40c8aa4471a64db4e7313206fa><c4533e40c8aa4471a64db4e7313206fa>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 9 0 R
+/Root 8 0 R
+/Size 14
+>>
+startxref
+6682
+%%EOF

--- a/src/z3c/rml/tests/input/tag-blockTable-11.rml
+++ b/src/z3c/rml/tests/input/tag-blockTable-11.rml
@@ -1,0 +1,198 @@
+<!DOCTYPE document SYSTEM "rml.dtd">
+<document
+    filename="tag-blockTable-11.pdf"
+    xmlns:doc="http://namespaces.zope.org/rml/doc">
+
+  <template>
+    <pageTemplate id="main">
+      <frame id="first" x1="72" y1="72" width="451" height="698"/>
+    </pageTemplate>
+  </template>
+
+ <stylesheet>
+    <blockTableStyle id="tablestyle">
+        <lineStyle kind="GRID" colorName="darkblue"/>
+    </blockTableStyle>
+</stylesheet>
+ 
+  <story>
+
+    <title>
+      <font face="Courier">&lt;blockTable&gt;</font> Tag Demo with Links
+    </title>
+
+    <bookmarkPage
+        name="top" fitType="fitv" zoom="2"
+        left="2cm" right="10cm" top="20cm"
+        />
+    <h1>Table that splits between rows</h1>
+
+    <blockTable style="tablestyle" colWidths="50% 50%" splitByRow="1" splitInRow="0">
+      <tr>
+        <td>
+            <para>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+            do eiusmod tempor incididunt ut labore et dolore magna aliqua. In
+            ante metus dictum at tempor commodo. Condimentum id venenatis a
+            condimentum vitae sapien. Et odio pellentesque diam volutpat commodo
+            sed egestas. Nibh venenatis cras sed felis. Pulvinar mattis nunc sed
+            blandit libero volutpat sed. Odio euismod lacinia at quis. Quis
+            blandit turpis cursus in hac. Condimentum id venenatis a condimentum
+            vitae sapien. Elementum facilisis leo vel fringilla.</para>
+        </td>
+        <td>
+        </td>
+      </tr>
+      <tr>
+        <td>
+            <para>Mi eget mauris pharetra et ultrices neque. Arcu cursus vitae
+            congue mauris rhoncus. Hac habitasse platea dictumst vestibulum
+            rhoncus. Ultrices neque ornare aenean euismod elementum nisi quis.
+            At tempor commodo ullamcorper a lacus vestibulum sed arcu. Dolor sit
+            amet consectetur adipiscing elit pellentesque. Tellus mauris a diam
+            maecenas sed. In dictum non consectetur a erat. Molestie a iaculis
+            at erat pellentesque adipiscing commodo elit. Amet venenatis urna
+            cursus eget nunc scelerisque. Mattis molestie a iaculis at erat
+            pellentesque adipiscing. At auctor urna nunc id cursus metus aliquam
+            eleifend mi. Amet mauris commodo quis imperdiet. Sed viverra ipsum
+            nunc aliquet bibendum enim facilisis gravida. Aliquam ultrices
+            sagittis orci a scelerisque purus semper eget. Amet volutpat
+            consequat mauris nunc congue nisi vitae suscipit tellus. Habitasse
+            platea dictumst quisque sagittis purus sit amet. Venenatis tellus in
+            metus vulputate eu scelerisque felis imperdiet proin. Pharetra magna
+            ac placerat vestibulum.</para>
+        </td>
+        <td>
+        </td>
+      </tr>
+      <tr>
+        <td>
+            <para>Neque viverra justo nec ultrices dui sapien eget. At varius
+            vel pharetra vel turpis nunc eget lorem. Massa ultricies mi quis
+            hendrerit dolor magna eget. Volutpat maecenas volutpat blandit
+            aliquam etiam erat velit. Nulla pharetra diam sit amet nisl suscipit
+            adipiscing bibendum est. Sagittis id consectetur purus ut faucibus
+            pulvinar elementum. Pellentesque habitant morbi tristique senectus.
+            Egestas sed tempus urna et pharetra pharetra. Vel elit scelerisque
+            mauris pellentesque pulvinar. Suspendisse interdum consectetur
+            libero id. Ipsum faucibus vitae aliquet nec ullamcorper sit amet
+            risus nullam. Id nibh tortor id aliquet lectus proin nibh nisl. Amet
+            tellus cras adipiscing enim. Lacus luctus accumsan tortor posuere ac
+            ut.</para>
+        </td>
+        <td>
+        </td>
+      </tr>
+      <tr>
+        <td>
+            <para>Facilisis sed odio morbi quis commodo odio aenean. Venenatis
+            urna cursus eget nunc scelerisque. Nullam non nisi est sit. Ac odio
+            tempor orci dapibus ultrices in iaculis nunc. Consectetur lorem
+            donec massa sapien faucibus et molestie. Ut sem nulla pharetra diam.
+            Elit duis tristique sollicitudin nibh sit amet commodo nulla
+            facilisi. Convallis tellus id interdum velit. Neque ornare aenean
+            euismod elementum nisi. Viverra aliquet eget sit amet tellus. Id
+            ornare arcu odio ut sem nulla pharetra. Semper quis lectus nulla at.
+            Id leo in vitae turpis massa sed elementum. Enim diam vulputate ut
+            pharetra.</para>
+        </td>
+        <td>
+        </td>
+      </tr>
+    </blockTable>
+
+    <h1>Table that splits in a row</h1>
+
+    <blockTable style="tablestyle" colWidths="50% 50%" splitByRow="0" splitInRow="1">
+      <tr>
+        <td>
+            <para>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
+            do eiusmod tempor incididunt ut labore et dolore magna aliqua. In
+            ante metus dictum at tempor commodo. Condimentum id venenatis a
+            condimentum vitae sapien. Et odio pellentesque diam volutpat commodo
+            sed egestas. Nibh venenatis cras sed felis. Pulvinar mattis nunc sed
+            blandit libero volutpat sed. Odio euismod lacinia at quis. Quis
+            blandit turpis cursus in hac. Condimentum id venenatis a condimentum
+            vitae sapien. Elementum facilisis leo vel fringilla.</para>
+        </td>
+        <td>
+        </td>
+      </tr>
+      <tr>
+        <td>
+            <para>Mi eget mauris pharetra et ultrices neque. Arcu cursus vitae
+            congue mauris rhoncus. Hac habitasse platea dictumst vestibulum
+            rhoncus. Ultrices neque ornare aenean euismod elementum nisi quis.
+            At tempor commodo ullamcorper a lacus vestibulum sed arcu. Dolor sit
+            amet consectetur adipiscing elit pellentesque. Tellus mauris a diam
+            maecenas sed. In dictum non consectetur a erat. Molestie a iaculis
+            at erat pellentesque adipiscing commodo elit. Amet venenatis urna
+            cursus eget nunc scelerisque. Mattis molestie a iaculis at erat
+            pellentesque adipiscing. At auctor urna nunc id cursus metus aliquam
+            eleifend mi. Amet mauris commodo quis imperdiet. Sed viverra ipsum
+            nunc aliquet bibendum enim facilisis gravida. Aliquam ultrices
+            sagittis orci a scelerisque purus semper eget. Amet volutpat
+            consequat mauris nunc congue nisi vitae suscipit tellus. Habitasse
+            platea dictumst quisque sagittis purus sit amet. Venenatis tellus in
+            metus vulputate eu scelerisque felis imperdiet proin. Pharetra magna
+            ac placerat vestibulum.</para>
+        </td>
+        <td>
+        </td>
+      </tr>
+      <tr>
+        <td>
+            <para>Neque viverra justo nec ultrices dui sapien eget. At varius
+            vel pharetra vel turpis nunc eget lorem. Massa ultricies mi quis
+            hendrerit dolor magna eget. Volutpat maecenas volutpat blandit
+            aliquam etiam erat velit. Nulla pharetra diam sit amet nisl suscipit
+            adipiscing bibendum est. Sagittis id consectetur purus ut faucibus
+            pulvinar elementum. Pellentesque habitant morbi tristique senectus.
+            Egestas sed tempus urna et pharetra pharetra. Vel elit scelerisque
+            mauris pellentesque pulvinar. Suspendisse interdum consectetur
+            libero id. Ipsum faucibus vitae aliquet nec ullamcorper sit amet
+            risus nullam. Id nibh tortor id aliquet lectus proin nibh nisl. Amet
+            tellus cras adipiscing enim. Lacus luctus accumsan tortor posuere ac
+            ut.</para>
+        </td>
+        <td>
+        </td>
+      </tr>
+      <tr>
+        <td>
+            <para>Facilisis sed odio morbi quis commodo odio aenean. Venenatis
+            urna cursus eget nunc scelerisque. Nullam non nisi est sit. Ac odio
+            tempor orci dapibus ultrices in iaculis nunc. Consectetur lorem
+            donec massa sapien faucibus et molestie. Ut sem nulla pharetra diam.
+            Elit duis tristique sollicitudin nibh sit amet commodo nulla
+            facilisi. Convallis tellus id interdum velit. Neque ornare aenean
+            euismod elementum nisi. Viverra aliquet eget sit amet tellus. Id
+            ornare arcu odio ut sem nulla pharetra. Semper quis lectus nulla at.
+            Id leo in vitae turpis massa sed elementum. Enim diam vulputate ut
+            pharetra.</para>
+        </td>
+        <td>
+        </td>
+      </tr>
+      <tr>
+        <td>
+            <para>Sapien nec sagittis aliquam malesuada bibendum arcu. Nibh
+            tortor id aliquet lectus proin nibh nisl. Tellus cras adipiscing
+            enim eu turpis. Arcu risus quis varius quam quisque id diam.
+            Habitant morbi tristique senectus et netus. Ullamcorper sit amet
+            risus nullam eget felis eget. Nunc pulvinar sapien et ligula. Enim
+            nunc faucibus a pellentesque sit. In hac habitasse platea dictumst
+            quisque. Amet purus gravida quis blandit turpis cursus in. Dignissim
+            diam quis enim lobortis scelerisque fermentum dui faucibus. Sapien
+            et ligula ullamcorper malesuada proin libero. Lectus arcu bibendum
+            at varius. Sed augue lacus viverra vitae congue eu. Urna duis
+            convallis convallis tellus id. Magna eget est lorem ipsum
+            dolor.</para>
+        </td>
+        <td>
+        </td>
+      </tr>
+    </blockTable>
+
+
+  </story>
+</document>


### PR DESCRIPTION
Reportlab has two options on BlockTables, splitByRow and splitInRow, which handles how tables are split when they don't fit on a page. This change allows you to set them on tables in rml.