### PR TITLE
Fix tests by not allowing `pillow >= 11`.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ envlist =
 [testenv]
 usedevelop = true
 deps =
+    pillow < 11
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
 extras =
@@ -49,6 +50,7 @@ allowlist_externals =
     mkdir
 deps =
     coverage
+    pillow < 11
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}


### PR DESCRIPTION
This is a temporary fix and it will not prevent
using new pillow versions outside the tests.

See #125.