### PR TITLE
Force `reportlab < 4.3` to heal tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@ CHANGES
   version.
   (`#125 <https://github.com/zopefoundation/z3c.rml/issues/125>_`)
 
+- As tests break with ``reportlab >= 4.3``, for now force the tests to use an
+  older version.
+  (`#127 <https://github.com/zopefoundation/z3c.rml/issues/127>_`)
+
 
 4.4.0 (2023-08-23)
 ------------------

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ envlist =
 usedevelop = true
 deps =
     pillow < 11
+    reportlab < 4.3
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
 extras =
@@ -51,6 +52,7 @@ allowlist_externals =
 deps =
     coverage
     pillow < 11
+    reportlab < 4.3
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}


### PR DESCRIPTION
See also #127.