### PR TITLE
Fix compatibility with reportlab >= 4.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,6 @@ CHANGES
 5.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
 - Fix compatibility with ``reportlab >= 4.3`` by using the proper PostScript
   font name ``Times-Roman`` instead of the informal ``Times`` shorthand.
   (`#127 <https://github.com/zopefoundation/z3c.rml/issues/127>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,13 @@ CHANGES
 
 - Nothing changed yet.
 
+- Fix compatibility with ``reportlab >= 4.3`` by using the proper PostScript
+  font name ``Times-Roman`` instead of the informal ``Times`` shorthand.
+  (`#127 <https://github.com/zopefoundation/z3c.rml/issues/127>`_)
+
+- Fix index callback registration to use ``setNamedCB`` API, required by
+  ``reportlab >= 4.5``.
+
 
 5.0.1 (2025-10-08)
 ------------------

--- a/src/z3c/rml/document.py
+++ b/src/z3c/rml/document.py
@@ -684,7 +684,7 @@ class Document(directive.RMLDirective):
         self.canvas = self.doc.canv
 
     def _initCanvas(self, canvas):
-        canvas._indexAdd = self._indexAdd
+        canvas.setNamedCB('_indexAdd', self._indexAdd)
         canvas.manager = self
         if self.pageLayout:
             canvas._doc._catalog.setPageLayout(self.pageLayout)

--- a/src/z3c/rml/document.py
+++ b/src/z3c/rml/document.py
@@ -684,7 +684,13 @@ class Document(directive.RMLDirective):
         self.canvas = self.doc.canv
 
     def _initCanvas(self, canvas):
-        canvas.setNamedCB('_indexAdd', self._indexAdd)
+        # TODO: Remove the conditional once support for reportlab < 4.4.8
+        # is dropped. setNamedCB was introduced in reportlab 4.4.8 as a
+        # security fix replacing direct canvas attribute assignment.
+        if hasattr(canvas, 'setNamedCB'):
+            canvas.setNamedCB('_indexAdd', self._indexAdd)
+        else:
+            canvas._indexAdd = self._indexAdd
         canvas.manager = self
         if self.pageLayout:
             canvas._doc._catalog.setPageLayout(self.pageLayout)

--- a/src/z3c/rml/tests/input/text-not-in-tags.rml
+++ b/src/z3c/rml/tests/input/text-not-in-tags.rml
@@ -16,7 +16,7 @@
   <stylesheet>
     <paraStyle
        name="Custom"
-       fontName="Times"
+       fontName="Times-Roman"
        fontSize="16pt"
        leading="18pt"
        textColor="red"

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,11 @@ minversion = 3.18
 envlist =
     release-check
     lint
+    py39
     py310
     py311
     py312
     py313
-    py314
     coverage
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
-# Generated from:
-# https://github.com/zopefoundation/meta/tree/master/config/pure-python
+# Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
+# https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 [tox]
 minversion = 3.18
 envlist =
     release-check
     lint
-    py39
     py310
     py311
     py312
     py313
+    py314
     coverage
 
 [testenv]
@@ -17,9 +17,8 @@ usedevelop = true
 package = wheel
 wheel_build_env = .pkg
 deps =
-    setuptools == 75.8.2
+    setuptools >= 78.1.1,< 82
     pillow < 11
-    reportlab < 4.3
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
 extras =
@@ -30,24 +29,23 @@ basepython = python3
 deps =
     git+https://github.com/pypa/setuptools.git\#egg=setuptools
     pillow < 11
-    reportlab < 4.3
 
 [testenv:release-check]
 description = ensure that the distribution is ready to release
 basepython = python3
 skip_install = true
 deps =
-    setuptools == 75.8.2
+    setuptools >= 78.1.1,< 82
     wheel
     twine
     build
     check-manifest
-    check-python-versions >= 0.20.0
+    check-python-versions >= 0.24.2
     wheel
 commands_pre =
 commands =
     check-manifest
-    check-python-versions --only setup.py,tox.ini,.github/workflows/tests.yml
+    check-python-versions --only pyproject.toml,setup.py,tox.ini,.github/workflows/tests.yml
     python -m build --sdist --no-isolation
     twine check dist/*
 
@@ -68,7 +66,6 @@ allowlist_externals =
 deps =
     coverage[toml]
     pillow < 11
-    reportlab < 4.3
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}


### PR DESCRIPTION
## Summary

Fixes #127 -- tests break with `reportlab >= 4.3`.

Two issues were found and fixed:

- **`KeyError: 'Times'` (reportlab >= 4.3):** The test file `text-not-in-tags.rml` used `fontName="Times"`, which is not a valid PostScript font name. Reportlab < 4.3 happened to resolve it internally via `tt2ps()`, but the paragraph code modernization in 4.3 removed that implicit mapping. Fixed by using the proper name `Times-Roman`.

- **`Missing index callback attribute '_indexAdd'` (reportlab >= 4.5):** The index callback was registered as a direct canvas attribute (`canvas._indexAdd = ...`), but reportlab 4.5 changed to look up callbacks via `canvas.getNamedCB()`. Fixed by using `canvas.setNamedCB('_indexAdd', ...)`.

The `reportlab < 4.3` pin has been removed from `tox.ini`. All 181 tests pass with reportlab 4.5.0 on Python 3.14.