### PR TITLE
Remove Pillow < 11 upper bound and fix EPS image handling for Pillow >= 11

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -13,9 +13,6 @@ with-macos = false
 with-docs = false
 with-free-threaded-python = false
 
-[tox]
-testenv-deps = ["pillow < 11"]
-
 [coverage]
 fail-under = 82
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,14 @@ CHANGES
 - Fix index callback registration to use ``setNamedCB`` API, required by
   ``reportlab >= 4.5``.
 
+- Remove the ``Pillow < 11`` upper version bound. Pillow >= 11 changed how
+  EPS images are loaded: the image mode can change after rasterization (e.g.
+  from RGB to 1-bit), which caused ``ValueError: No packer found from 1 to
+  RGB`` in reportlab's ``ImageReader``. Fix by pre-loading images and
+  converting them back to their initial mode when Pillow changes it during
+  load.
+  (`#125 <https://github.com/zopefoundation/z3c.rml/issues/125>`_)
+
 
 5.0.1 (2025-10-08)
 ------------------

--- a/src/z3c/rml/attr.py
+++ b/src/z3c/rml/attr.py
@@ -477,7 +477,22 @@ class Image(File):
         fileObj = super().fromUnicode(value)
         if self.onlyOpen:
             return fileObj
-        return reportlab.lib.utils.ImageReader(fileObj)
+        return self._create_image_reader(fileObj)
+
+    @staticmethod
+    def _create_image_reader(fileObj):
+        from PIL import Image as PILImage
+        img = PILImage.open(fileObj)
+        initial_mode = img.mode
+        img.load()
+        if img.mode != initial_mode:
+            # Pillow >= 11 may change the image mode after load(), e.g. EPS
+            # images switch from RGB to 1-bit mode after rasterization. This
+            # confuses reportlab's ImageReader.getRGBData() which checks the
+            # mode before loading. Convert back to the initial mode so
+            # reportlab can process the image correctly.
+            img = img.convert(initial_mode)
+        return reportlab.lib.utils.ImageReader(img)
 
     def _load_svg(self, value):
         manager = getManager(self.context)

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ package = wheel
 wheel_build_env = .pkg
 deps =
     setuptools >= 78.1.1,< 82
-    pillow < 11
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
 extras =
@@ -28,7 +27,6 @@ extras =
 basepython = python3
 deps =
     git+https://github.com/pypa/setuptools.git\#egg=setuptools
-    pillow < 11
 
 [testenv:release-check]
 description = ensure that the distribution is ready to release
@@ -65,7 +63,6 @@ allowlist_externals =
     mkdir
 deps =
     coverage[toml]
-    pillow < 11
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}


### PR DESCRIPTION
## Summary

- Remove the `pillow < 11` version constraint from `tox.ini` and `.meta.toml` to allow compatibility with Python 3.14 (where Pillow < 11 fails to build).
- Fix `ValueError: No packer found from 1 to RGB` when rendering EPS images with Pillow >= 11.

## Problem

Pillow >= 11 changed how EPS images are loaded: `Image.open()` initially reports mode `RGB`, but after `.load()` (which triggers Ghostscript rasterization) the mode silently changes to `1` (1-bit). Reportlab's `ImageReader.getRGBData()` checks the mode *before* loading, sees `RGB`, and skips conversion. When `tobytes()` is later called, it triggers the actual load, at which point the mode is `1` and the raw encoder fails trying to pack 1-bit data as RGB.

## Fix

Pre-load PIL images in `attr.Image._create_image_reader()` and detect when the mode changes after `load()`. If it does, convert the image back to the initial mode before passing it to reportlab's `ImageReader`. This ensures reportlab always sees a stable, consistent image mode.

Fixes #125 