### PR TITLE
Fix compatibility with reportlab >= 5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ CHANGES
 5.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix compatibility with ``reportlab >= 5`` which refuses to open ``file://``
+  and ``data:`` URLs unless a trusted host is configured. Local files are now
+  passed to reportlab as a plain absolute path, and ``data:`` URIs are decoded
+  directly. The fix remains compatible with ``reportlab 4.x``.
 
 
 5.1.1 (2026-05-21)

--- a/src/z3c/rml/attr.py
+++ b/src/z3c/rml/attr.py
@@ -19,6 +19,7 @@ import logging
 import os
 import re
 import urllib.parse
+import urllib.request
 from importlib import import_module
 
 import reportlab.graphics.widgets.markers
@@ -449,14 +450,23 @@ class File(Text):
         # module resolution.
         if self.doNotModify:
             return value
-        # All platforms need a protocol for local files:
-        if not urllib.parse.urlparse(value).scheme:
-            value = 'file:///' + os.path.abspath(value)
+        # Local files are passed as a plain absolute filesystem path.
+        # Historically a ``file://`` URL was used here, but reportlab >= 5
+        # refuses to open ``file://`` URLs unless their host is listed in
+        # ``reportlab.rl_config.trustedHosts`` (empty by default), so we hand
+        # reportlab the bare path, which it opens directly via ``open()``.
+        scheme = urllib.parse.urlparse(value).scheme
+        if not scheme:
+            value = os.path.abspath(value)
         # If the file is not to be opened, simply return the path.
         if self.doNotOpen:
             return value
-        # Open/Download the file
-        fileObj = reportlab.lib.utils.open_for_read(value)
+        # Open/Download the file. reportlab >= 5 also refuses to open ``data:``
+        # URIs unless a trusted host is configured, so decode those ourselves.
+        if scheme == 'data':
+            fileObj = urllib.request.urlopen(value)
+        else:
+            fileObj = reportlab.lib.utils.open_for_read(value)
         sio = io.BytesIO(fileObj.read())
         fileObj.close()
         sio.seek(0)

--- a/src/z3c/rml/document.py
+++ b/src/z3c/rml/document.py
@@ -429,7 +429,7 @@ class LogConfig(directive.RMLDirective):
     def process(self):
         args = dict(self.getAttributeValues())
         logger = logging.getLogger(LOGGER_NAME)
-        handler = logging.FileHandler(args['filename'][8:], args['filemode'])
+        handler = logging.FileHandler(args['filename'], args['filemode'])
         formatter = logging.Formatter(
             args.get('format'), args.get('datefmt'))
         handler.setFormatter(formatter)


### PR DESCRIPTION
## Problem

The test suite started failing (33 errors) with the release of **reportlab 5.0.0**. CI runs from a week ago passed because they resolved reportlab 4.x.

reportlab 5.0.0 added a `trustedHosts` security gate: `reportlab.lib.utils.open_for_read` now refuses to open `file://` and `data:` URLs unless a trusted host is configured (default `trustedHosts = None`). z3c.rml had been wrapping every local file path in a `file://` URL before handing it to reportlab, which now raises `OSError: Cannot open resource 'file:////...'`.

## Fix

- **`attr.py`** (`File.fromUnicode`): pass local files to reportlab as a plain absolute path (it opens those directly via `open()`), and decode `data:` URIs ourselves via `urllib.request` instead of routing through the now-gated `open_for_read`.
- **`document.py`** (`LogConfig.process`): drop the `[8:]` slice that stripped the old `file:///` prefix from the log filename; with a plain path returned, that slice corrupted it.

## Testing

- reportlab **5.0.0**: 181 tests, 0 failures, 0 errors ✅
- reportlab **4.5.1**: 181 tests pass ✅

The fix is version-independent and needs no version pin.

— _Comment created by Claude_
